### PR TITLE
feat: implicit closure capture in FunctionSpace arguments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,4 +235,6 @@ Cargo.lock
 
 *.f360
 
-poetry.lock
+poetry.lockuv.lock
+
+uv.lock

--- a/src/coker/algebra/kernel.py
+++ b/src/coker/algebra/kernel.py
@@ -5,7 +5,6 @@ import scipy as sp
 from typing import Callable, Union, Tuple, List, Optional, Set, Iterable, Any
 from collections import defaultdict
 
-
 from coker.algebra.dimensions import (
     Dimension,
     VectorSpace,
@@ -64,6 +63,10 @@ def get_dim_by_class(arg):
 
     raise NotImplementedError(f"Don't know the shape of {type(arg)}")
 
+class DanglingTracerError(Exception):
+    def __init__(self, *args, tracers: List['Tracer']):
+        super().__init__(*args)
+        self.tracers = tracers
 
 class TapeInner:
     INNER_REF = -1
@@ -214,10 +217,18 @@ class Tape:
     def append(self, op: OP, *args) -> int:
         args = [strip_symbols_from_array(a) for a in args]
 
+        invalid_tracers = [
+            arg for arg in args
+            if isinstance(arg,Tracer) and arg.tape != self
+        ]
+        if invalid_tracers:
+            raise DanglingTracerError(tracers=invalid_tracers)
+
         args = [
             self.insert_value(a) if not isinstance(a, Tracer) else a.copy()
             for a in args
         ]
+
         out_dim = self._compute_shape(op, *args)
         index = len(self.dim)
         self.nodes.push_op(op, *args)
@@ -583,6 +594,9 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         return Tracer(self.tape, output)
 
     def __call__(self, *args):
+        for arg in args:
+            if isinstance(arg, Tracer):
+                assert arg.tape == self.tape
         index = self.tape.append(OP.EVALUATE, self, *args)
         return Tracer(self.tape, index)
 
@@ -679,7 +693,12 @@ class Function:
             if isinstance(arg, Function):
                 return arg
 
-            return function(self.tape.dim[index].arguments, arg, self.backend)
+            try:
+                return function(self.tape.dim[index].arguments, arg, self.backend)
+            except DanglingTracerError as ex:
+
+
+                raise NotImplementedError from ex
 
         return arg
 
@@ -831,7 +850,6 @@ def function(
     # create symbols
     # call function to construct expression graph
 
-    tape = Tape()
     with TraceContext() as tape:
         args = [tape.input(v) for v in arguments]
         result = implementation(*args)
@@ -862,7 +880,7 @@ def function(
         if isinstance(result, Tracer) and result.index == tape.NONE:
             result = None
 
-    return Function(tape, result, backend, name)
+        return Function(tape, result, backend, name)
 
 
 def strip_symbols_from_array(array: np.ndarray, float_type=float):
@@ -984,17 +1002,20 @@ def if_then_else(expression, true_branch, false_branch):
 
 
 _local = threading.local()
-
+_local.trace = []
 
 class TraceContext:
     def __enter__(self):
         tape = Tape()
-        _local.trace = tape
+        _local.trace.append(tape)
         return tape
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        _local.trace = None
+        _local.trace.pop()
 
     @staticmethod
     def get_local_tape() -> Tape | None:
-        return getattr(_local, "trace", None)
+        if not _local.trace:
+            return None
+        return _local.trace[-1]
+

--- a/src/coker/algebra/kernel.py
+++ b/src/coker/algebra/kernel.py
@@ -48,9 +48,6 @@ def get_projection(dimension: Dimension, slc: slice):
     return proj
 
 
-Inferred = None
-
-
 def get_dim_by_class(arg):
     if isinstance(arg, scalar_types):
         return Dimension(None)
@@ -63,21 +60,22 @@ def get_dim_by_class(arg):
 
     raise NotImplementedError(f"Don't know the shape of {type(arg)}")
 
+
 class DanglingTracerError(Exception):
-    def __init__(self, *args, tracers: List['Tracer']):
+    def __init__(self, *args, tracers: List["Tracer"]):
         super().__init__(*args)
         self.tracers = tracers
 
 
-def _find_closure_tracers(callable) -> dict:
-    """Return all Tracer objects captured in a callable's closure.
+def _find_closure_tracers(fn) -> dict:
+    """Return all Tracer objects captured in fn's closure.
 
     Returns a dict keyed by (tape_id, tracer_index) so duplicates are collapsed.
     """
     captured = {}
-    if not (hasattr(callable, '__code__') and callable.__closure__):
+    if not (hasattr(fn, "__code__") and fn.__closure__):
         return captured
-    for cell in callable.__closure__:
+    for cell in fn.__closure__:
         try:
             val = cell.cell_contents
             if isinstance(val, Tracer):
@@ -85,6 +83,7 @@ def _find_closure_tracers(callable) -> dict:
         except ValueError:
             pass
     return captured
+
 
 class TapeInner:
     INNER_REF = -1
@@ -242,13 +241,16 @@ class Tape:
 
         if self._substitutions:
             args = [
-                self._substitutions.get((id(a.tape), a.index), a) if isinstance(a, Tracer) else a
+                (
+                    self._substitutions.get((id(a.tape), a.index), a)
+                    if isinstance(a, Tracer)
+                    else a
+                )
                 for a in args
             ]
 
         invalid_tracers = [
-            arg for arg in args
-            if isinstance(arg, Tracer) and arg.tape != self
+            arg for arg in args if isinstance(arg, Tracer) and arg.tape != self
         ]
         if invalid_tracers:
             raise DanglingTracerError(tracers=invalid_tracers)
@@ -356,6 +358,11 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         ctx = TraceContext.get_local_tape()
         return ctx if ctx is not None else self.tape
 
+    def _emit(self, op: OP, *args) -> "Tracer":
+        """Append op to the active tape and return the resulting Tracer."""
+        tape = self._active_tape()
+        return Tracer(tape, tape.append(op, *args))
+
     def copy(self):
         return Tracer(self.tape, self.index)
 
@@ -417,72 +424,51 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         return f"Tape {self.tape}:{self.index}"
 
     def __mul__(self, other):
-        tape = self._active_tape()
-        index = tape.append(OP.MUL, self, other)
-        return Tracer(tape, index)
+        return self._emit(OP.MUL, self, other)
 
     def __rmul__(self, other):
-        tape = self._active_tape()
-        index = tape.append(OP.MUL, other, self)
-        return Tracer(tape, index)
+        return self._emit(OP.MUL, other, self)
+
+    def __sub__(self, other):
+        return self._emit(OP.SUB, self, other)
+
+    def __matmul__(self, other):
+        return self._emit(OP.MATMUL, self, other)
+
+    def __rmatmul__(self, other):
+        assert other.shape[0] > 0
+        return self._emit(OP.MATMUL, other, self)
 
     def __add__(self, other):
         tape = self._active_tape()
         if is_additive_identity(other, self):
             return self
-
         if not isinstance(other, Tracer):
             other = tape.insert_value(other)
-
         if self.dim.is_scalar() and not other.dim.is_scalar():
             return self * np.ones(other.shape) + other
         elif not self.dim.is_scalar() and other.dim.is_scalar():
             return self + other * np.ones(self.shape)
-
-        index = tape.append(OP.ADD, self, other)
-        return Tracer(tape, index)
+        return self._emit(OP.ADD, self, other)
 
     def __radd__(self, other):
         tape = self._active_tape()
         if is_additive_identity(self.dim, other):
             return self
-
         if not isinstance(other, Tracer):
             other = tape.insert_value(other)
-
         return other + self
 
-    def __sub__(self, other):
-        tape = self._active_tape()
-        index = tape.append(OP.SUB, self, other)
-        return Tracer(tape, index)
-
-    def __rmatmul__(self, other):
-        tape = self._active_tape()
-        index = tape.append(OP.MATMUL, other, self)
-        assert other.shape[0] > 0
-        return Tracer(tape, index)
-
-    def __matmul__(self, other):
-        tape = self._active_tape()
-        index = tape.append(OP.MATMUL, self, other)
-        return Tracer(tape, index)
-
     def __pow__(self, power, modulo=None):
-        tape = self._active_tape()
         if isinstance(power, float) and power == 0.5:
-            index = tape.append(OP.SQRT, self)
-        elif isinstance(power, int):
+            return self._emit(OP.SQRT, self)
+        if isinstance(power, int):
             return self._do_integer_power(power)
-        else:
-            index = tape.append(OP.PWR, self, power)
-        return Tracer(tape, index)
+        return self._emit(OP.PWR, self, power)
 
     @property
     def T(self):
-        tape = self._active_tape()
-        index = tape.append(OP.TRANSPOSE, self)
-        return Tracer(tape, index)
+        return self._emit(OP.TRANSPOSE, self)
 
     def _do_integer_power(self, power):
         if power <= 0:
@@ -497,7 +483,6 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         if self.is_constant():
             return self.value()[key]
 
-        tape = self._active_tape()
         if isinstance(key, slice):
             dimension = self.tape.dim[self.index]
             if isinstance(dimension, FunctionSpace):
@@ -507,15 +492,13 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
             else:
                 assert dimension.is_vector(), f"Tried to index a vector"
                 p = get_projection(dimension, key)
-            index = tape.append(OP.MATMUL, p, self)
-            return Tracer(tape, index)
+            return self._emit(OP.MATMUL, p, self)
 
-        elif isinstance(key, int):
+        if isinstance(key, int):
             dimension = self.tape.dim[self.index]
             assert dimension.is_vector(), f"Tried to index a vector"
             p = get_basis(dimension, key)
-            index = tape.append(OP.DOT, p, self)
-            return Tracer(tape, index)
+            return self._emit(OP.DOT, p, self)
 
         raise NotImplementedError(
             "Cannot get key {}, not yet implemented", key
@@ -561,69 +544,47 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
             yield self[i]
 
     def __le__(self, other):
-        tape = self._active_tape()
-        idx = tape.append(OP.LESS_EQUAL, self, other)
-        return Tracer(tape, idx)
+        return self._emit(OP.LESS_EQUAL, self, other)
 
     def __ge__(self, other):
-        tape = self._active_tape()
-        idx = tape.append(OP.LESS_EQUAL, other, self)
-        return Tracer(tape, idx)
+        return self._emit(OP.LESS_EQUAL, other, self)
 
     def __lt__(self, other):
-        tape = self._active_tape()
-        idx = tape.append(OP.LESS_THAN, self, other)
-        return Tracer(tape, idx)
+        return self._emit(OP.LESS_THAN, self, other)
 
     def __gt__(self, other):
-        tape = self._active_tape()
-        idx = tape.append(OP.LESS_THAN, other, self)
-        return Tracer(tape, idx)
+        return self._emit(OP.LESS_THAN, other, self)
 
     def __eq__(self, other):
-        tape = self._active_tape()
-        idx = tape.append(OP.EQUAL, self, other)
-        return Tracer(tape, idx)
+        return self._emit(OP.EQUAL, self, other)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
-        tape = self._active_tape()
         if (
             ufunc == np.matmul
             and isinstance(inputs[0], np.ndarray)
             and inputs[0].shape[0] == 0
         ):
+            tape = self._active_tape()
             return Tracer(tape, tape.NONE)
-
-        try:
-            op = numpy_atomics[ufunc]
-            index = tape.append(op, *inputs)
-            return Tracer(tape, index)
-        except KeyError:
-            pass
-
         if ufunc == np.less:
             lhs, rhs = inputs
             return rhs > lhs
-
+        try:
+            return self._emit(numpy_atomics[ufunc], *inputs)
+        except KeyError:
+            pass
         raise NotImplementedError(f"{ufunc} is not implemented")
 
     def __array_function__(self, func, types, args, kwargs):
-        tape = self._active_tape()
         try:
-            op = numpy_atomics[func]
-            index = tape.append(op, *args)
-            return Tracer(tape, index)
+            return self._emit(numpy_atomics[func], *args)
         except KeyError:
             pass
-
         try:
             op = numpy_composites[func](**kwargs)
-            args = op.pre_process(*args)
-            index = tape.append(op, *args)
-            return Tracer(tape, index)
+            return self._emit(op, *op.pre_process(*args))
         except KeyError:
             pass
-
         raise NotImplementedError(f"{func} with {kwargs} is not implemented")
 
     def norm(self):
@@ -633,16 +594,11 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         return np.sqrt(np.dot(self, self))
 
     def normalise(self):
-        tape = self._active_tape()
         norm = self.norm()
-        condition = norm == 0
-        output = tape.append(OP.CASE, condition, self, self / norm)
-        return Tracer(tape, output)
+        return self._emit(OP.CASE, norm == 0, self, self / norm)
 
     def __call__(self, *args):
-        tape = self._active_tape()
-        index = tape.append(OP.EVALUATE, self, *args)
-        return Tracer(tape, index)
+        return self._emit(OP.EVALUATE, self, *args)
 
 
 class Function:
@@ -738,22 +694,28 @@ class Function:
                 return arg
 
             try:
-                return function(self.tape.dim[index].arguments, arg, self.backend)
+                return function(
+                    self.tape.dim[index].arguments, arg, self.backend
+                )
             except DanglingTracerError as ex:
-                return self._lift_closure(arg, self.tape.dim[index], ex)
+                return self._lift_closure(
+                    arg, self.tape.dim[index], ex
+                )  # arg is a Python callable
 
         return arg
 
-    def _lift_closure(self, callable, space: FunctionSpace, ex: DanglingTracerError) -> "_BoundFunction":
-        """Re-trace callable with captured outer-tape tracers promoted to extra inputs.
+    def _lift_closure(
+        self, fn, space: FunctionSpace, ex: DanglingTracerError
+    ) -> "_BoundFunction":
+        """Re-trace fn with captured outer-tape tracers promoted to extra inputs.
 
         Creates a new inner tape with extra inputs for each captured tracer, registers
-        substitution rules so that uses of the outer tracers inside the callable are
+        substitution rules so that uses of the outer tracers inside fn are
         transparently rewritten to the corresponding inner inputs during re-tracing,
         then wraps the result in a _BoundFunction that supplies the captured values
         at call time.
         """
-        captured = _find_closure_tracers(callable)
+        captured = _find_closure_tracers(fn)
         if not captured:
             raise NotImplementedError from ex
 
@@ -771,26 +733,15 @@ class Function:
         all_spaces = list(space.arguments) + extra_spaces
         inner_tape = Tape()
         all_inner_args = [inner_tape.input(v) for v in all_spaces]
-        orig_inner_args = all_inner_args[:len(space.arguments)]
-        cap_inner_args = all_inner_args[len(space.arguments):]
+        orig_inner_args = all_inner_args[: len(space.arguments)]
+        cap_inner_args = all_inner_args[len(space.arguments) :]
 
         for outer_t, inner_t in zip(unique_captured, cap_inner_args):
             inner_tape.add_substitution(outer_t, inner_t)
 
         with TraceContext(inner_tape):
-            result = callable(*orig_inner_args)
-
-            if isinstance(result, np.ndarray):
-                result = strip_symbols_from_array(result)
-            if isinstance(result, SymbolicVector):
-                result = result.collapse()
-            if isinstance(result, (list, tuple)):
-                result = [r if isinstance(r, Tracer) else inner_tape.insert_value(r) for r in result]
-            else:
-                if not isinstance(result, Tracer):
-                    result = inner_tape.insert_value(result)
-            if isinstance(result, Tracer) and result.index == inner_tape.NONE:
-                result = None
+            output = fn(*orig_inner_args)
+            result = _normalise_result(output, inner_tape)
 
         inner_fn = Function(inner_tape, result, self.backend)
         return _BoundFunction(inner_fn, unique_captured)
@@ -924,6 +875,30 @@ class InequalityExpression:
         self.upper = upper
 
 
+def _normalise_result(result, tape: Tape):
+    """Normalise an implementation's return value into Tracer(s) on tape."""
+    if isinstance(result, np.ndarray):
+        result = strip_symbols_from_array(result)
+    if isinstance(result, SymbolicVector):
+        result = result.collapse()
+
+    def wrap(v):
+        if isinstance(v, np.ndarray):
+            v = strip_symbols_from_array(v)
+        if isinstance(v, SymbolicVector):
+            v = v.collapse()
+        return v if isinstance(v, Tracer) else tape.insert_value(v)
+
+    if isinstance(result, (list, tuple)):
+        result = [wrap(r) for r in result]
+    else:
+        result = wrap(result)
+
+    if isinstance(result, Tracer) and result.index == tape.NONE:
+        return None
+    return result
+
+
 def function(
     arguments: List[Scalar | VectorSpace | FunctionSpace],
     implementation: Callable[[Element, ...], Element],
@@ -961,39 +936,10 @@ def function(
         >>> f(np.array([1.0, 0.0, 0.0]))
         array([1., 0., 0.])
     """
-    # create symbols
-    # call function to construct expression graph
-
     with TraceContext() as tape:
         args = [tape.input(v) for v in arguments]
-        result = implementation(*args)
-
-        if isinstance(result, np.ndarray):
-            result = strip_symbols_from_array(result)
-
-        if isinstance(result, SymbolicVector):
-            result = result.collapse()
-
-        def wrap(v):
-            if isinstance(v, np.ndarray):
-                v = strip_symbols_from_array(v)
-            if isinstance(v, SymbolicVector):
-                v = v.collapse()
-
-            if isinstance(v, Tracer):
-                return v
-
-            return tape.insert_value(v)
-
-        if isinstance(result, (list, tuple)):
-            result = [wrap(r) for r in result]
-
-        else:
-            result = wrap(result)
-
-        if isinstance(result, Tracer) and result.index == tape.NONE:
-            result = None
-
+        output = implementation(*args)
+        result = _normalise_result(output, tape)
         return Function(tape, result, backend, name)
 
 
@@ -1118,6 +1064,7 @@ def if_then_else(expression, true_branch, false_branch):
 _local = threading.local()
 _local.trace = []
 
+
 class TraceContext:
     def __init__(self, tape: "Tape | None" = None):
         self._tape = tape
@@ -1136,4 +1083,3 @@ class TraceContext:
         if not _local.trace:
             return None
         return _local.trace[-1]
-

--- a/src/coker/algebra/kernel.py
+++ b/src/coker/algebra/kernel.py
@@ -68,6 +68,24 @@ class DanglingTracerError(Exception):
         super().__init__(*args)
         self.tracers = tracers
 
+
+def _find_closure_tracers(callable) -> dict:
+    """Return all Tracer objects captured in a callable's closure.
+
+    Returns a dict keyed by (tape_id, tracer_index) so duplicates are collapsed.
+    """
+    captured = {}
+    if not (hasattr(callable, '__code__') and callable.__closure__):
+        return captured
+    for cell in callable.__closure__:
+        try:
+            val = cell.cell_contents
+            if isinstance(val, Tracer):
+                captured[(id(val.tape), val.index)] = val
+        except ValueError:
+            pass
+    return captured
+
 class TapeInner:
     INNER_REF = -1
     CONSTANT_REF = -2
@@ -160,6 +178,11 @@ class Tape:
         self.dim = []
         self.input_indicies = []
         self.input_names = []
+        self._substitutions: dict = {}
+
+    def add_substitution(self, foreign: "Tracer", local: "Tracer"):
+        """Register a rewrite rule: any occurrence of foreign in append args is replaced by local."""
+        self._substitutions[(id(foreign.tape), foreign.index)] = local
 
     def op(self, i):
         return self.nodes[i][0]
@@ -217,9 +240,15 @@ class Tape:
     def append(self, op: OP, *args) -> int:
         args = [strip_symbols_from_array(a) for a in args]
 
+        if self._substitutions:
+            args = [
+                self._substitutions.get((id(a.tape), a.index), a) if isinstance(a, Tracer) else a
+                for a in args
+            ]
+
         invalid_tracers = [
             arg for arg in args
-            if isinstance(arg,Tracer) and arg.tape != self
+            if isinstance(arg, Tracer) and arg.tape != self
         ]
         if invalid_tracers:
             raise DanglingTracerError(tracers=invalid_tracers)
@@ -316,6 +345,17 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
     def tape(self):
         return self._tape()
 
+    def _active_tape(self) -> "Tape":
+        """Return the tape that operations on this Tracer should be recorded on.
+
+        During tracing the current TraceContext tape is returned so that all ops
+        land on the active tape (which may differ from self.tape when a closure
+        captures a tracer from an enclosing trace). Falls back to self.tape when
+        no TraceContext is active.
+        """
+        ctx = TraceContext.get_local_tape()
+        return ctx if ctx is not None else self.tape
+
     def copy(self):
         return Tracer(self.tape, self.index)
 
@@ -377,67 +417,72 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         return f"Tape {self.tape}:{self.index}"
 
     def __mul__(self, other):
-        index = self.tape.append(OP.MUL, self, other)
-        return Tracer(self.tape, index)
+        tape = self._active_tape()
+        index = tape.append(OP.MUL, self, other)
+        return Tracer(tape, index)
 
     def __rmul__(self, other):
-        index = self.tape.append(OP.MUL, other, self)
-
-        return Tracer(self.tape, index)
+        tape = self._active_tape()
+        index = tape.append(OP.MUL, other, self)
+        return Tracer(tape, index)
 
     def __add__(self, other):
+        tape = self._active_tape()
         if is_additive_identity(other, self):
             return self
 
         if not isinstance(other, Tracer):
-            other = self.tape.insert_value(other)
+            other = tape.insert_value(other)
 
         if self.dim.is_scalar() and not other.dim.is_scalar():
             return self * np.ones(other.shape) + other
         elif not self.dim.is_scalar() and other.dim.is_scalar():
             return self + other * np.ones(self.shape)
 
-        index = self.tape.append(OP.ADD, self, other)
-        return Tracer(self.tape, index)
+        index = tape.append(OP.ADD, self, other)
+        return Tracer(tape, index)
 
     def __radd__(self, other):
+        tape = self._active_tape()
         if is_additive_identity(self.dim, other):
             return self
 
         if not isinstance(other, Tracer):
-            other = self.tape.insert_value(other)
+            other = tape.insert_value(other)
 
         return other + self
 
     def __sub__(self, other):
-        index = self.tape.append(OP.SUB, self, other)
-        return Tracer(self.tape, index)
+        tape = self._active_tape()
+        index = tape.append(OP.SUB, self, other)
+        return Tracer(tape, index)
 
     def __rmatmul__(self, other):
-        index = self.tape.append(OP.MATMUL, other, self)
-
+        tape = self._active_tape()
+        index = tape.append(OP.MATMUL, other, self)
         assert other.shape[0] > 0
-        return Tracer(self.tape, index)
+        return Tracer(tape, index)
 
     def __matmul__(self, other):
-        index = self.tape.append(OP.MATMUL, self, other)
-        return Tracer(self.tape, index)
+        tape = self._active_tape()
+        index = tape.append(OP.MATMUL, self, other)
+        return Tracer(tape, index)
 
     def __pow__(self, power, modulo=None):
+        tape = self._active_tape()
         if isinstance(power, float) and power == 0.5:
-            index = self.tape.append(OP.SQRT, self)
+            index = tape.append(OP.SQRT, self)
         elif isinstance(power, int):
             return self._do_integer_power(power)
-
         else:
-            index = self.tape.append(OP.PWR, self, power)
-
-        return Tracer(self.tape, index)
+            index = tape.append(OP.PWR, self, power)
+        return Tracer(tape, index)
 
     @property
     def T(self):
-        index = self.tape.append(OP.TRANSPOSE, self)
-        return Tracer(self.tape, index)
+        tape = self._active_tape()
+        index = tape.append(OP.TRANSPOSE, self)
+        return Tracer(tape, index)
 
     def _do_integer_power(self, power):
         if power <= 0:
@@ -452,6 +497,7 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         if self.is_constant():
             return self.value()[key]
 
+        tape = self._active_tape()
         if isinstance(key, slice):
             dimension = self.tape.dim[self.index]
             if isinstance(dimension, FunctionSpace):
@@ -461,15 +507,15 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
             else:
                 assert dimension.is_vector(), f"Tried to index a vector"
                 p = get_projection(dimension, key)
-            index = self.tape.append(OP.MATMUL, p, self)
-            return Tracer(self.tape, index)
+            index = tape.append(OP.MATMUL, p, self)
+            return Tracer(tape, index)
 
         elif isinstance(key, int):
             dimension = self.tape.dim[self.index]
             assert dimension.is_vector(), f"Tried to index a vector"
             p = get_basis(dimension, key)
-            index = self.tape.append(OP.DOT, p, self)
-            return Tracer(self.tape, index)
+            index = tape.append(OP.DOT, p, self)
+            return Tracer(tape, index)
 
         raise NotImplementedError(
             "Cannot get key {}, not yet implemented", key
@@ -515,64 +561,66 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
             yield self[i]
 
     def __le__(self, other):
-        idx = self.tape.append(OP.LESS_EQUAL, self, other)
-        return Tracer(self.tape, idx)
+        tape = self._active_tape()
+        idx = tape.append(OP.LESS_EQUAL, self, other)
+        return Tracer(tape, idx)
 
     def __ge__(self, other):
-        idx = self.tape.append(OP.LESS_EQUAL, other, self)
-        return Tracer(self.tape, idx)
+        tape = self._active_tape()
+        idx = tape.append(OP.LESS_EQUAL, other, self)
+        return Tracer(tape, idx)
 
     def __lt__(self, other):
-        idx = self.tape.append(OP.LESS_THAN, self, other)
-        return Tracer(self.tape, idx)
+        tape = self._active_tape()
+        idx = tape.append(OP.LESS_THAN, self, other)
+        return Tracer(tape, idx)
 
     def __gt__(self, other):
-        idx = self.tape.append(OP.LESS_THAN, other, self)
-        return Tracer(self.tape, idx)
+        tape = self._active_tape()
+        idx = tape.append(OP.LESS_THAN, other, self)
+        return Tracer(tape, idx)
 
     def __eq__(self, other):
-        idx = self.tape.append(OP.EQUAL, self, other)
-        return Tracer(self.tape, idx)
+        tape = self._active_tape()
+        idx = tape.append(OP.EQUAL, self, other)
+        return Tracer(tape, idx)
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
+        tape = self._active_tape()
         if (
             ufunc == np.matmul
             and isinstance(inputs[0], np.ndarray)
             and inputs[0].shape[0] == 0
         ):
-            return Tracer(self.tape, self.tape.NONE)
+            return Tracer(tape, tape.NONE)
 
         try:
             op = numpy_atomics[ufunc]
-
-            index = self.tape.append(op, *inputs)
-            return Tracer(self.tape, index)
-
+            index = tape.append(op, *inputs)
+            return Tracer(tape, index)
         except KeyError:
             pass
 
         if ufunc == np.less:
-            # lhs -> numpy item
-            # rhs -> Tracer
-            # op lhs < rhs
             lhs, rhs = inputs
             return rhs > lhs
 
         raise NotImplementedError(f"{ufunc} is not implemented")
 
     def __array_function__(self, func, types, args, kwargs):
+        tape = self._active_tape()
         try:
             op = numpy_atomics[func]
-            index = self.tape.append(op, *args)
-            return Tracer(self.tape, index)
+            index = tape.append(op, *args)
+            return Tracer(tape, index)
         except KeyError:
             pass
 
         try:
             op = numpy_composites[func](**kwargs)
             args = op.pre_process(*args)
-            index = self.tape.append(op, *args)
-            return Tracer(self.tape, index)
+            index = tape.append(op, *args)
+            return Tracer(tape, index)
         except KeyError:
             pass
 
@@ -585,20 +633,16 @@ class Tracer(np.lib.mixins.NDArrayOperatorsMixin):
         return np.sqrt(np.dot(self, self))
 
     def normalise(self):
+        tape = self._active_tape()
         norm = self.norm()
-
         condition = norm == 0
-
-        output = self.tape.append(OP.CASE, condition, self, self / norm)
-
-        return Tracer(self.tape, output)
+        output = tape.append(OP.CASE, condition, self, self / norm)
+        return Tracer(tape, output)
 
     def __call__(self, *args):
-        for arg in args:
-            if isinstance(arg, Tracer):
-                assert arg.tape == self.tape
-        index = self.tape.append(OP.EVALUATE, self, *args)
-        return Tracer(self.tape, index)
+        tape = self._active_tape()
+        index = tape.append(OP.EVALUATE, self, *args)
+        return Tracer(tape, index)
 
 
 class Function:
@@ -696,11 +740,60 @@ class Function:
             try:
                 return function(self.tape.dim[index].arguments, arg, self.backend)
             except DanglingTracerError as ex:
-
-
-                raise NotImplementedError from ex
+                return self._lift_closure(arg, self.tape.dim[index], ex)
 
         return arg
+
+    def _lift_closure(self, callable, space: FunctionSpace, ex: DanglingTracerError) -> "_BoundFunction":
+        """Re-trace callable with captured outer-tape tracers promoted to extra inputs.
+
+        Creates a new inner tape with extra inputs for each captured tracer, registers
+        substitution rules so that uses of the outer tracers inside the callable are
+        transparently rewritten to the corresponding inner inputs during re-tracing,
+        then wraps the result in a _BoundFunction that supplies the captured values
+        at call time.
+        """
+        captured = _find_closure_tracers(callable)
+        if not captured:
+            raise NotImplementedError from ex
+
+        unique_captured: List[Tracer] = list(captured.values())
+
+        extra_spaces = []
+        for i, t in enumerate(unique_captured):
+            dim = t.dim
+            if not isinstance(dim, Dimension):
+                raise NotImplementedError(
+                    "Capturing FunctionSpace-typed tracers is not supported"
+                ) from ex
+            extra_spaces.append(dim.to_space(f"_cap_{i}"))
+
+        all_spaces = list(space.arguments) + extra_spaces
+        inner_tape = Tape()
+        all_inner_args = [inner_tape.input(v) for v in all_spaces]
+        orig_inner_args = all_inner_args[:len(space.arguments)]
+        cap_inner_args = all_inner_args[len(space.arguments):]
+
+        for outer_t, inner_t in zip(unique_captured, cap_inner_args):
+            inner_tape.add_substitution(outer_t, inner_t)
+
+        with TraceContext(inner_tape):
+            result = callable(*orig_inner_args)
+
+            if isinstance(result, np.ndarray):
+                result = strip_symbols_from_array(result)
+            if isinstance(result, SymbolicVector):
+                result = result.collapse()
+            if isinstance(result, (list, tuple)):
+                result = [r if isinstance(r, Tracer) else inner_tape.insert_value(r) for r in result]
+            else:
+                if not isinstance(result, Tracer):
+                    result = inner_tape.insert_value(result)
+            if isinstance(result, Tracer) and result.index == inner_tape.NONE:
+                result = None
+
+        inner_fn = Function(inner_tape, result, self.backend)
+        return _BoundFunction(inner_fn, unique_captured)
 
     def call_inline(self, *args) -> Tuple[Tracer]:
         """Evaluate this function symbolically inside an active tracing context.
@@ -795,6 +888,27 @@ class Function:
         assert dim.shape == other.shape, "Arguments have different shapes"
         ones = np.ones_like(other)
         return InequalityExpression(self, other, ones * np.inf, is_equal=False)
+
+
+class _BoundFunction(Function):
+    """A Function whose extra tail inputs are pre-bound to captured outer-tape tracers.
+
+    Created by Function._lift_closure when a Python callable passed as a
+    FunctionSpace argument closes over tracers from an enclosing trace.
+    """
+
+    def __init__(self, inner_fn: Function, captured: List[Tracer]):
+        self.name = inner_fn.name
+        self.tape = inner_fn.tape
+        self.backend = inner_fn.backend
+        self._compiled = None
+        self.output = inner_fn.output
+        self.is_single = inner_fn.is_single
+        self._inner = inner_fn
+        self._captured = captured
+
+    def __call__(self, *args):
+        return self._inner(*args, *self._captured)
 
 
 class InequalityExpression:
@@ -1005,10 +1119,14 @@ _local = threading.local()
 _local.trace = []
 
 class TraceContext:
+    def __init__(self, tape: "Tape | None" = None):
+        self._tape = tape
+
     def __enter__(self):
-        tape = Tape()
-        _local.trace.append(tape)
-        return tape
+        if self._tape is None:
+            self._tape = Tape()
+        _local.trace.append(self._tape)
+        return self._tape
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         _local.trace.pop()

--- a/tests/backends/casadi/test_higher_order_composition.py
+++ b/tests/backends/casadi/test_higher_order_composition.py
@@ -205,7 +205,9 @@ def test_casadi_inner_with_functionspace_called_from_casadi_outer():
     # inner: (u: R->R, x: R, p: R) -> u(x) * p
     inner = function(
         arguments=[
-            FunctionSpace("u", arguments=[Scalar("t")], output=[Scalar("u(t)")]),
+            FunctionSpace(
+                "u", arguments=[Scalar("t")], output=[Scalar("u(t)")]
+            ),
             Scalar("x"),
             Scalar("p"),
         ],
@@ -239,7 +241,9 @@ def test_casadi_inner_with_functionspace_closure_over_outer_variable():
     # inner: (u: R->R, x: R) -> u(x)
     inner = function(
         arguments=[
-            FunctionSpace("u", arguments=[Scalar("t")], output=[Scalar("u(t)")]),
+            FunctionSpace(
+                "u", arguments=[Scalar("t")], output=[Scalar("u(t)")]
+            ),
             Scalar("x"),
         ],
         implementation=lambda u, x: u(x),
@@ -251,7 +255,6 @@ def test_casadi_inner_with_functionspace_closure_over_outer_variable():
     def outer_impl(a, x):
         u_closure = lambda t: a * t  # noqa: E731
         return inner(u_closure, x) + a
-
 
     outer = function(
         arguments=[Scalar("a"), Scalar("x")],

--- a/tests/backends/casadi/test_higher_order_composition.py
+++ b/tests/backends/casadi/test_higher_order_composition.py
@@ -1,0 +1,265 @@
+"""Tests for higher-order function composition across backends.
+
+Verifies that a function compiled with the default ("coker") backend can be
+passed as a FunctionSpace argument into a "casadi"-compiled outer function
+and evaluated correctly.  This pattern appears in Mechanica whenever a
+body-level CasADi system calls individual compartment evaluators whose
+boundary-flow inputs are Python callables.
+"""
+
+import numpy as np
+import pytest
+
+try:
+    import casadi as ca
+
+    casadi_available = True
+except ImportError:
+    casadi_available = False
+
+from coker import function, Scalar, VectorSpace, FunctionSpace
+
+
+pytestmark = pytest.mark.skipif(
+    not casadi_available, reason="CasADi not available"
+)
+
+
+# ---------------------------------------------------------------------------
+# Scalar composition
+# ---------------------------------------------------------------------------
+
+
+def test_scalar_coker_function_in_casadi_outer():
+    """coker-backend scalar f passed into casadi-backend outer function."""
+
+    inner = function(
+        arguments=[Scalar("x")],
+        implementation=lambda x: x**2,
+        backend="coker",
+    )
+
+    outer = function(
+        arguments=[
+            FunctionSpace("f", arguments=[Scalar("x")], output=[Scalar("y")]),
+            Scalar("x"),
+        ],
+        implementation=lambda f, x: f(x) + x + 1,
+        backend="casadi",
+    )
+
+    # f(x) = x^2 + x + 1;  at x=3: 9+3+1 = 13
+    result = outer(inner, 3.0)
+    assert abs(result - 13.0) < 1e-9, f"Expected 13.0, got {result}"
+
+
+def test_plain_callable_in_casadi_outer():
+    """A plain Python callable (no tape) passed into a casadi-backend outer."""
+
+    def plain_square(x):
+        return x**2
+
+    outer = function(
+        arguments=[
+            FunctionSpace("f", arguments=[Scalar("x")], output=[Scalar("y")]),
+            Scalar("x"),
+        ],
+        implementation=lambda f, x: f(x) + x,
+        backend="casadi",
+    )
+
+    # f(x) = x^2 + x;  at x=4: 16+4 = 20
+    result = outer(plain_square, 4.0)
+    assert abs(result - 20.0) < 1e-9, f"Expected 20.0, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Vector composition
+# ---------------------------------------------------------------------------
+
+
+def test_vector_coker_function_in_casadi_outer():
+    """coker-backend vector f(x)->y passed into casadi-backend outer."""
+
+    # inner: R^2 -> R^2, doubles each element
+    inner = function(
+        arguments=[VectorSpace("x", 2)],
+        implementation=lambda x: 2 * x,
+        backend="coker",
+    )
+
+    outer = function(
+        arguments=[
+            FunctionSpace(
+                "f",
+                arguments=[VectorSpace("x", 2)],
+                output=[VectorSpace("y", 2)],
+            ),
+            VectorSpace("x", 2),
+        ],
+        implementation=lambda f, x: f(x) + x,
+        backend="casadi",
+    )
+
+    # f(x) = 2x + x = 3x; at x=[1,2]: [3,6]
+    x_val = np.array([1.0, 2.0])
+    result = outer(inner, x_val)
+    expected = np.array([3.0, 6.0])
+    assert np.allclose(result, expected), f"Expected {expected}, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# FunctionSpace input that itself calls into the outer symbolic context
+# ---------------------------------------------------------------------------
+
+
+def test_casadi_outer_passes_symbolic_arg_to_inner():
+    """The outer function evaluates the inner at a *symbolic* sub-expression.
+
+    This mirrors the Mechanica pattern where the body-level CasADi system
+    calls a spatial evaluator with a symbolic parameter vector ``p``, and
+    the evaluator internally calls ``u(t)`` with symbolic ``t``.
+    """
+
+    # inner: R -> R, computes sin(x)
+    inner = function(
+        arguments=[Scalar("x")],
+        implementation=lambda x: np.sin(x),
+        backend="coker",
+    )
+
+    # outer: f, a, x -> f(a * x)
+    # The inner is called at the *derived* value (a*x), not at x directly.
+    outer = function(
+        arguments=[
+            FunctionSpace("f", arguments=[Scalar("x")], output=[Scalar("y")]),
+            Scalar("a"),
+            Scalar("x"),
+        ],
+        implementation=lambda f, a, x: f(a * x),
+        backend="casadi",
+    )
+
+    a_val, x_val = 2.0, 0.5
+    result = outer(inner, a_val, x_val)
+    expected = np.sin(a_val * x_val)
+    assert abs(result - expected) < 1e-9, f"Expected {expected}, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Nested: coker inner called from casadi middle, middle from casadi outer
+# ---------------------------------------------------------------------------
+
+
+def test_three_level_nesting():
+    """Three-level nesting: coker leaf inside casadi middle inside casadi outer."""
+
+    leaf = function(
+        arguments=[Scalar("x")],
+        implementation=lambda x: x + 1,
+        backend="coker",
+    )
+
+    middle = function(
+        arguments=[
+            FunctionSpace("f", arguments=[Scalar("x")], output=[Scalar("y")]),
+            Scalar("x"),
+        ],
+        implementation=lambda f, x: f(x) * 2,
+        backend="casadi",
+    )
+
+    outer = function(
+        arguments=[
+            FunctionSpace("g", arguments=[Scalar("x")], output=[Scalar("y")]),
+            Scalar("x"),
+        ],
+        implementation=lambda g, x: g(x) - x,
+        backend="casadi",
+    )
+
+    # middle(leaf, x) = (x+1)*2
+    # outer(middle(leaf,·), x) = middle(leaf, x) - x = (x+1)*2 - x = x+2
+    # at x=5: 7
+    result = outer(lambda x: middle(leaf, x), 5.0)
+    assert abs(result - 7.0) < 1e-9, f"Expected 7.0, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# Casadi inner with FunctionSpace input called from casadi outer
+# (mirrors the Mechanica body-evaluator → spatial-evaluator pattern)
+# ---------------------------------------------------------------------------
+
+
+def test_casadi_inner_with_functionspace_called_from_casadi_outer():
+    """casadi-backend inner that itself has a FunctionSpace input, called
+    from a casadi-backend outer.
+
+    This mirrors the Mechanica pattern:
+      - "inner" ~ spatial evaluator dxdt: (t, x, p, u) -> dx  where u is a
+        FunctionSpace (boundary flow callable)
+      - "outer" ~ body-level dxdt: calls inner with a closure over its own
+        accumulated boundary flow variable
+    """
+
+    # inner: (u: R->R, x: R, p: R) -> u(x) * p
+    inner = function(
+        arguments=[
+            FunctionSpace("u", arguments=[Scalar("t")], output=[Scalar("u(t)")]),
+            Scalar("x"),
+            Scalar("p"),
+        ],
+        implementation=lambda u, x, p: u(x) * p,
+        backend="casadi",
+    )
+
+    # outer: (x: R, p: R) -> inner(u=lambda t: t+1, x, p) + x
+    # where u is built from outer's own variables (here just a closure over x)
+    def outer_impl(x, p):
+        u_closure = lambda t: t + 1  # noqa: E731 — plain callable, no tape
+        return inner(u_closure, x, p) + x
+
+    outer = function(
+        arguments=[Scalar("x"), Scalar("p")],
+        implementation=outer_impl,
+        backend="casadi",
+    )
+
+    # inner(u, x=2, p=3) = u(2)*3 = 3*3 = 9;  outer = 9 + 2 = 11
+    result = outer(2.0, 3.0)
+    assert abs(result - 11.0) < 1e-9, f"Expected 11.0, got {result}"
+
+
+@pytest.mark.skip(reason="implicit closure capture not yet implemented")
+def test_casadi_inner_with_functionspace_closure_over_outer_variable():
+    """The FunctionSpace argument passed to the inner function closes over a
+    variable from the outer function — the closure must carry the symbolic
+    value through correctly.
+    """
+
+    # inner: (u: R->R, x: R) -> u(x)
+    inner = function(
+        arguments=[
+            FunctionSpace("u", arguments=[Scalar("t")], output=[Scalar("u(t)")]),
+            Scalar("x"),
+        ],
+        implementation=lambda u, x: u(x),
+        backend="casadi",
+    )
+
+    # outer: (a: R, x: R) -> inner(u=lambda t: a*t, x) + a
+    # u closes over `a`, an outer parameter
+    def outer_impl(a, x):
+        u_closure = lambda t: a * t  # noqa: E731
+        return inner(u_closure, x) + a
+
+
+    outer = function(
+        arguments=[Scalar("a"), Scalar("x")],
+        implementation=outer_impl,
+        backend="casadi",
+    )
+
+    # inner(u, x=3) = a*3;  outer = a*3 + a = a*4; at a=2: 8
+    result = outer(2.0, 3.0)
+    assert abs(result - 8.0) < 1e-9, f"Expected 8.0, got {result}"

--- a/tests/backends/casadi/test_higher_order_composition.py
+++ b/tests/backends/casadi/test_higher_order_composition.py
@@ -230,7 +230,6 @@ def test_casadi_inner_with_functionspace_called_from_casadi_outer():
     assert abs(result - 11.0) < 1e-9, f"Expected 11.0, got {result}"
 
 
-@pytest.mark.skip(reason="implicit closure capture not yet implemented")
 def test_casadi_inner_with_functionspace_closure_over_outer_variable():
     """The FunctionSpace argument passed to the inner function closes over a
     variable from the outer function — the closure must carry the symbolic


### PR DESCRIPTION
## Summary

- Adds cross-tape validation to `Tape.append` via `DanglingTracerError` — catches when a tracer from a foreign tape is used in an operation
- Implements implicit closure capture: Python callables passed as `FunctionSpace` arguments can now close over outer-trace variables without any change to the public API
- Refactors `Tracer` operator methods to use a new `_emit()` helper and `_active_tape()` dispatch; extracts `_normalise_result()` shared by `function()` and `_lift_closure()`

## How it works

When a closure like `lambda t: a * t` (where `a` is an outer-tape tracer) is passed as a `FunctionSpace` argument, `Function._lift_closure` detects the captured tracers via `__closure__` inspection, creates an inner tape with extra inputs for each, registers substitution rules, then re-traces the closure inside a `TraceContext`. `Tracer._active_tape()` ensures ops dispatch to the active inner tape during re-tracing, where substitutions transparently replace the outer tracers. The result is a `_BoundFunction` that splices the captured values in at call time.

## Test plan

- [ ] `test_casadi_inner_with_functionspace_closure_over_outer_variable` — new test, now passing
- [ ] All 201 existing tests pass, 3 skipped (JAX backend, not installed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)