### PR TITLE
Add CasADi variational iteration callbacks

### DIFF
--- a/src/coker/backends/backend.py
+++ b/src/coker/backends/backend.py
@@ -3,15 +3,9 @@ from typing import Any, Tuple, Type
 from coker.algebra.kernel import Function, Tracer
 from typing import List, Dict
 
-from coker.dynamics import (
-    VariationalProblem,
-    SolverParameters
-)
+from coker.dynamics import VariationalProblem, SolverParameters
 
 ArrayLike = Any
-
-
-
 
 
 class Backend(metaclass=ABCMeta):

--- a/src/coker/backends/backend.py
+++ b/src/coker/backends/backend.py
@@ -5,17 +5,13 @@ from typing import List, Dict
 
 from coker.dynamics import (
     VariationalProblem,
-    create_autonomous_ode,
-    DynamicsSpec,
+    SolverParameters
 )
 
 ArrayLike = Any
 
 
-class SolverParameters(metaclass=ABCMeta):
-    """Interface for backend-specific ODE solver configuration."""
 
-    pass
 
 
 class Backend(metaclass=ABCMeta):

--- a/src/coker/backends/casadi/variational_solver.py
+++ b/src/coker/backends/casadi/variational_solver.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Callable, List, Dict, Optional, Tuple
 
 import casadi as ca
 import numpy as np
@@ -250,18 +250,11 @@ def create_variational_solver(problem: VariationalProblem):
         lbg = ca.vertcat(lbg, g_lower)
         ubg = ca.vertcat(ubg, g_upper)
 
-    solver_options = problem.transcription_options.optimiser_options
-
-    f_out = ca.Function(
-        "Output",
-        [decision_variables],
-        [path_symbols, u_symbols, p],
-        {},
+    projectors = tuple(
+        _to_output_projector(proj) for proj in (proj_x, proj_z, proj_q)
     )
 
-    
-
-
+    solver_options = dict(problem.transcription_options.optimiser_options)
     if not problem.transcription_options.verbose:
         solver_options.update(
             {
@@ -270,6 +263,38 @@ def create_variational_solver(problem: VariationalProblem):
                 "ipopt.sb": "yes",
             }
         )
+
+    init_solver_options = dict(solver_options)
+    nlp_solver_options = dict(solver_options)
+
+    f_out = ca.Function(
+        "Output",
+        [decision_variables],
+        [path_symbols, u_symbols, p],
+        {},
+    )
+
+    callback_wrapper = None
+    if problem.transcription_options.interation_callback is not None:
+        callback_wrapper = CallbackWrapper.new(
+            "variational_iteration_callback",
+            problem.transcription_options.interation_callback,
+            nx=decision_variables.shape[0],
+            ng=g.shape[0],
+            f_out=f_out,
+            poly_collection=poly_collection,
+            projectors=projectors,
+            proj_p=proj_p,
+            output_function=problem.system.y,
+            path_constraints=problem.path_constraints,
+            terminal_constraints=problem.terminal_constraints,
+            t_final=problem.t_final,
+            decode_controls=(
+                control_factory.to_output_array if problem.control else None
+            ),
+        )
+        nlp_solver_options["iteration_callback"] = callback_wrapper
+
     u0_guess = ca.DM.zeros(u_symbols.shape)
 
     state_guess = ca.vertcat(
@@ -292,7 +317,7 @@ def create_variational_solver(problem: VariationalProblem):
             "g": ca.vertcat(g, p_symbols, u_symbols),
         }
         init_solver = ca.nlpsol(
-            "initialiser", "ipopt", init_spec, solver_options
+            "initialiser", "ipopt", init_spec, init_solver_options
         )
 
         init_soln = init_solver(
@@ -309,7 +334,7 @@ def create_variational_solver(problem: VariationalProblem):
         ), f"Cost at guess {initial_cost} is not finite"
 
     nlp_spec = {"f": cost, "x": decision_variables, "g": g}
-    nlp_solver = ca.nlpsol("solver", "ipopt", nlp_spec, solver_options)
+    nlp_solver = ca.nlpsol("solver", "ipopt", nlp_spec, nlp_solver_options)
     soln = nlp_solver(
         x0=decision_variables_0,
         lbx=lower_bound,
@@ -321,18 +346,9 @@ def create_variational_solver(problem: VariationalProblem):
     min_loss = float(soln["f"])
     min_args = soln["x"]
 
-
     x_out, u_out, p_out = f_out(min_args)
 
     path = poly_collection.to_fixed(np.array(x_out))
-    projectors = tuple(
-        (
-            np.array(proj.to_DM()).reshape(proj.shape)
-            if proj.shape != (0, 1)
-            else None
-        )
-        for proj in (proj_x, proj_z, proj_q)
-    )
     p_out = np.array(p_out)
     parameter_out = p_output_map(p_out)
 
@@ -549,3 +565,286 @@ class ControlFactory:
                 self.variables, self.offsets, self.sizes
             )
         ]
+
+
+def _to_output_projector(proj: ca.MX) -> Optional[np.ndarray]:
+    if proj.shape == (0, 1):
+        return None
+    return np.array(proj.to_DM()).reshape(proj.shape)
+
+
+def _to_flat_array(value) -> np.ndarray:
+    if value is None:
+        return np.zeros((0,))
+
+    if isinstance(value, (tuple, list)):
+        assert len(value) == 1, "Expected a single output value"
+        (value,) = value
+
+    array = np.array(value, dtype=float)
+    return array.reshape((-1,))
+
+
+def _evaluate_violation(raw_value, lower, upper) -> np.ndarray:
+    values = _to_flat_array(raw_value)
+    lower_bounds = _to_flat_array(lower)
+    upper_bounds = _to_flat_array(upper)
+    assert (
+        values.shape == lower_bounds.shape == upper_bounds.shape
+    ), "Constraint bounds do not match constraint values"
+
+    violations = []
+    for value_i, lower_i, upper_i in zip(values, lower_bounds, upper_bounds):
+        has_lower = np.isfinite(lower_i)
+        has_upper = np.isfinite(upper_i)
+        if has_lower and has_upper:
+            raise ValueError(
+                "Variational iteration callbacks only support half-space constraints per component"
+            )
+        if has_lower:
+            violations.append(max(lower_i - value_i, 0.0))
+        elif has_upper:
+            violations.append(max(value_i - upper_i, 0.0))
+
+    if not violations:
+        return np.zeros((0,))
+
+    return np.array(violations, dtype=float)
+
+
+class CallbackControlProxy:
+    def __init__(self, control_solutions):
+        self.control_solutions = control_solutions
+
+    def __call__(self, t) -> np.ndarray:
+        return np.array([control(t) for control in self.control_solutions])
+
+
+class CallbackTrajectoryProxy:
+    def __init__(
+        self,
+        path: InterpolatingPolyCollection,
+        evaluator: Callable[[float], np.ndarray],
+    ):
+        self.path = path
+        self.intervals = path.intervals
+        self._evaluator = evaluator
+
+    def __call__(self, t) -> np.ndarray:
+        return _to_flat_array(self._evaluator(t))
+
+    def interval_starts(self):
+        for t, _ in self.path.interval_starts():
+            yield t, self(t)
+
+    def interval_ends(self):
+        for t, _ in self.path.interval_ends():
+            yield t, self(t)
+
+    def knot_points(self):
+        for t, _, _ in self.path.knot_points():
+            yield t, self(t), None
+
+
+class _CallbackIterate:
+    def __init__(
+        self,
+        *,
+        path: InterpolatingPolyCollection,
+        projectors: Tuple[
+            Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]
+        ],
+        control_solutions,
+        parameters: np.ndarray,
+        system_parameters: np.ndarray,
+        output_function,
+        path_constraints,
+        terminal_constraints,
+    ):
+        self.path = path
+        self.projectors = projectors
+        self.control_solutions = control_solutions
+        self.parameters = parameters
+        self.system_parameters = system_parameters
+        self.output_function = output_function
+        self.path_constraints = path_constraints
+        self.terminal_constraints = terminal_constraints
+
+    def state(self, t) -> np.ndarray:
+        projector = self.projectors[0]
+        assert projector is not None
+        return projector @ self.path(t)
+
+    def algebraic(self, t) -> Optional[np.ndarray]:
+        projector = self.projectors[1]
+        if projector is None:
+            return None
+        return projector @ self.path(t)
+
+    def quadratures(self, t) -> Optional[np.ndarray]:
+        projector = self.projectors[2]
+        if projector is None:
+            return None
+        return projector @ self.path(t)
+
+    def control_law(self, t) -> Optional[np.ndarray]:
+        if self.control_solutions is None:
+            return None
+        return np.array([control(t) for control in self.control_solutions])
+
+    def _args_at(self, t):
+        return (
+            t,
+            self.state(t),
+            self.algebraic(t),
+            self.control_law(t),
+            self.system_parameters,
+            self.quadratures(t),
+        )
+
+    def output(self, t) -> np.ndarray:
+        return _to_flat_array(self.output_function(*self._args_at(t)))
+
+    def constraint_violations(self, constraints, t) -> np.ndarray:
+        if not constraints:
+            return np.zeros((0,))
+
+        args = self._args_at(t)
+        violations = [
+            _evaluate_violation(
+                constraint.value(*args), constraint.lower, constraint.upper
+            )
+            for constraint in constraints
+        ]
+        return np.concatenate(violations) if violations else np.zeros((0,))
+
+    def path_constraint_trajectory(self) -> CallbackTrajectoryProxy:
+        return CallbackTrajectoryProxy(
+            self.path,
+            lambda t: self.constraint_violations(self.path_constraints, t),
+        )
+
+    def terminal_constraint_vector(self, t_final: float) -> np.ndarray:
+        return self.constraint_violations(self.terminal_constraints, t_final)
+
+
+class CallbackWrapper(ca.Callback):
+    """Wrap a CasADi NLP iteration callback into the variational callback API."""
+
+    def __init__(
+        self,
+        name: str,
+        callback,
+        *,
+        nx: int,
+        ng: int,
+        f_out: ca.Function,
+        poly_collection: SymbolicPolyCollection,
+        projectors: Tuple[
+            Optional[np.ndarray], Optional[np.ndarray], Optional[np.ndarray]
+        ],
+        proj_p: ca.DM,
+        output_function,
+        path_constraints,
+        terminal_constraints,
+        t_final: float,
+        decode_controls: Optional[Callable[[ca.DM], list]],
+        opts=None,
+    ):
+        ca.Callback.__init__(self)
+        self.callback = callback
+        self.nx = nx
+        self.ng = ng
+        self.f_out = f_out
+        self.poly_collection = poly_collection
+        self.projectors = projectors
+        self.proj_p = proj_p
+        self.output_function = output_function
+        self.path_constraints = path_constraints
+        self.terminal_constraints = terminal_constraints
+        self.t_final = t_final
+        self.decode_controls = decode_controls
+        self.construct(name, {} if opts is None else opts)
+
+    @staticmethod
+    def new(*args, **kwargs) -> "CallbackWrapper":
+        return CallbackWrapper(*args, **kwargs)
+
+    def get_n_in(self):
+        return ca.nlpsol_n_out()
+
+    def get_n_out(self):
+        return 1
+
+    def get_name_in(self, i):
+        return ca.nlpsol_out(i)
+
+    def get_name_out(self, _i):
+        return "ret"
+
+    def get_sparsity_in(self, i):
+        name = ca.nlpsol_out(i)
+        if name == "f":
+            return ca.Sparsity.scalar()
+        if name in ("x", "lam_x"):
+            return ca.Sparsity.dense(self.nx, 1)
+        if name in ("g", "lam_g"):
+            return ca.Sparsity.dense(self.ng, 1)
+        return ca.Sparsity(0, 0)
+
+    def eval(self, arg):
+        darg = {name: value for name, value in zip(ca.nlpsol_out(), arg)}
+        decision_variables = darg["x"]
+        loss = float(darg["f"])
+
+        path_coefficients, control_coefficients, parameters = self.f_out(
+            decision_variables
+        )
+        path = self.poly_collection.to_fixed(np.array(path_coefficients))
+        parameter_vector = np.array(parameters, dtype=float).reshape((-1,))
+        system_parameters = np.array(
+            self.proj_p @ ca.DM(parameter_vector.reshape((-1, 1)))
+        ).reshape((-1,))
+        control_solutions = (
+            self.decode_controls(control_coefficients)
+            if self.decode_controls is not None
+            else None
+        )
+
+        iterate = _CallbackIterate(
+            path=path,
+            projectors=self.projectors,
+            control_solutions=control_solutions,
+            parameters=parameter_vector,
+            system_parameters=system_parameters,
+            output_function=self.output_function,
+            path_constraints=self.path_constraints,
+            terminal_constraints=self.terminal_constraints,
+        )
+
+        x = CallbackTrajectoryProxy(path, iterate.state)
+        z = (
+            CallbackTrajectoryProxy(path, iterate.algebraic)
+            if self.projectors[1] is not None
+            else None
+        )
+        q = (
+            CallbackTrajectoryProxy(path, iterate.quadratures)
+            if self.projectors[2] is not None
+            else None
+        )
+        u = (
+            CallbackControlProxy(control_solutions)
+            if control_solutions is not None
+            else None
+        )
+        y = CallbackTrajectoryProxy(path, iterate.output)
+        c_path = iterate.path_constraint_trajectory()
+        c_terminal = iterate.terminal_constraint_vector(self.t_final)
+
+        should_continue = bool(
+            self.callback(
+                x, z, q, parameter_vector, u, y, loss, c_path, c_terminal
+            )
+        )
+        return [0 if should_continue else 1]

--- a/src/coker/backends/casadi/variational_solver.py
+++ b/src/coker/backends/casadi/variational_solver.py
@@ -252,6 +252,16 @@ def create_variational_solver(problem: VariationalProblem):
 
     solver_options = problem.transcription_options.optimiser_options
 
+    f_out = ca.Function(
+        "Output",
+        [decision_variables],
+        [path_symbols, u_symbols, p],
+        {},
+    )
+
+    
+
+
     if not problem.transcription_options.verbose:
         solver_options.update(
             {
@@ -311,12 +321,7 @@ def create_variational_solver(problem: VariationalProblem):
     min_loss = float(soln["f"])
     min_args = soln["x"]
 
-    f_out = ca.Function(
-        "Output",
-        [decision_variables],
-        [path_symbols, u_symbols, p],
-        {},
-    )
+
     x_out, u_out, p_out = f_out(min_args)
 
     path = poly_collection.to_fixed(np.array(x_out))

--- a/src/coker/dynamics/types.py
+++ b/src/coker/dynamics/types.py
@@ -18,6 +18,7 @@ from typing import Dict
 
 class SolverParameters(metaclass=abc.ABCMeta):
     """Interface for backend-specific ODE solver configuration."""
+
     pass
 
 
@@ -227,15 +228,19 @@ LossFunction = Callable[[Solution, ControlLaw, ValueType], Scalar]
 
 class VartionalIterationCallback:
 
-    def __call__(self,
-                 x: Callable[[float], np.ndarray],
-                 z: Callable[[float], np.ndarray],
-                 q: Callable[[float], np.ndarray],
-                 p: float,
-                 u: Callable[[float], np.ndarray],
-                 loss:float,
-                 c_path: Callable[[float], np.ndarray],
-                 c_terminal:np.ndarray) -> bool:
+    def __call__(
+        self,
+        x: Callable[[float], np.ndarray],
+        z: Callable[[float], np.ndarray],
+        q: Callable[[float], np.ndarray],
+        p: float,
+        u: Callable[[float], np.ndarray],
+        y: Callable[[float], np.ndarray],
+        loss: float,
+        c_path: Callable[[float], np.ndarray],
+        c_terminal: np.ndarray,
+        **kwargs,
+    ) -> bool:
         """Wrapper class to handle callbacks at the end of each optimisation step.
 
         Args:
@@ -247,6 +252,7 @@ class VartionalIterationCallback:
             loss: Loss value
             c_path: Path constraint violation
             c_terminal: Terminal constraint violation
+            **kwargs: Solver-specific arguments.
 
         Returns:
               True if the solver should continue.

--- a/src/coker/dynamics/types.py
+++ b/src/coker/dynamics/types.py
@@ -16,6 +16,11 @@ import numpy as np
 from typing import Dict
 
 
+class SolverParameters(metaclass=abc.ABCMeta):
+    """Interface for backend-specific ODE solver configuration."""
+    pass
+
+
 @dataclass
 class DynamicsSpec:
     inputs: FunctionSpace
@@ -210,14 +215,47 @@ class ConstantControlVariable(ParameterMixin):
 Constant = Union[float, int]
 ValueType = Scalar | VectorSpace
 ControlLaw = Callable[[Scalar], ValueType]
-ControlVariable = (
+ControlVariable = Union[
     ConstantControlVariable | PiecewiseConstantVariable | SpikeVariable
-)
+]
 ParameterVariable = BoundedVariable | Constant
 Solution = Union[
     DynamicalSystem, Callable[[Scalar, ControlLaw, ValueType], Scalar]
 ]
 LossFunction = Callable[[Solution, ControlLaw, ValueType], Scalar]
+
+
+class VartionalIterationCallback:
+
+    def __call__(self,
+                 x: Callable[[float], np.ndarray],
+                 z: Callable[[float], np.ndarray],
+                 q: Callable[[float], np.ndarray],
+                 p: float,
+                 u: Callable[[float], np.ndarray],
+                 loss:float,
+                 c_path: Callable[[float], np.ndarray],
+                 c_terminal:np.ndarray) -> bool:
+        """Wrapper class to handle callbacks at the end of each optimisation step.
+
+        Args:
+            x: State trajectory (function of time)
+            z: Control trajectory (function of time)
+            q: Quadrature trajectory (function of time)
+            p: Parameter values
+            u: Control law (function of time)
+            loss: Loss value
+            c_path: Path constraint violation
+            c_terminal: Terminal constraint violation
+
+        Returns:
+              True if the solver should continue.
+
+        The shapes of each argument should line up with the `VariationalProblem` class attributes.
+
+        """
+
+        return True
 
 
 @dataclass
@@ -228,6 +266,7 @@ class TranscriptionOptions:
     verbose: bool = False
     optimiser_options: dict = field(default_factory=dict)
     initialise_near_guess: bool = True
+    interation_callback: Optional[VartionalIterationCallback] = None
 
 
 @dataclass

--- a/tests/dynamical_systems/test_variational_solver_callback.py
+++ b/tests/dynamical_systems/test_variational_solver_callback.py
@@ -1,0 +1,159 @@
+import numpy as np
+import pytest
+
+from coker import VectorSpace
+
+from coker.dynamics import (
+    BoundedVariable,
+    VariationalProblem,
+    create_autonomous_ode,
+)
+
+
+class LossCheckingCallback:
+    def __init__(self, sample_times, solution, param):
+        self.sample_times = sample_times
+        self.solution = solution
+        self.param = param
+        self.loss_differences = []
+        self.losses = []
+
+    def __call__(
+        self,
+        x,
+        z,
+        q,
+        p,
+        u,
+        y,
+        loss,
+        c_path,
+        c_terminal,
+        **_kwargs,
+    ):
+
+        assert z is None
+        assert q is None
+        assert u is None
+        assert p.shape == self.param.shape
+        assert c_terminal.shape == (0,)
+        assert c_path(0.5).shape == (0,)
+
+        recomputed_loss = 0.0
+        for t_i in self.sample_times:
+            y_i = np.atleast_1d(y(t_i))
+            x_i = np.atleast_1d(x(t_i))
+            truth = np.atleast_1d(self.solution(t_i, self.param))
+            error = truth - y_i
+            recomputed_loss += float(error.T @ error)
+            assert np.allclose(x_i, y_i)
+
+        self.losses.append(loss)
+        self.loss_differences.append(abs(loss - recomputed_loss))
+        return True
+
+
+def test_variational_iteration_callback_loss_matches_payload(
+    variational_backend,
+):
+    def x0(p):
+        return p[0]
+
+    def xdot(x, p):
+        return p[1]
+
+    param = np.array([2.0, 1.0])
+    sample_times = np.arange(0.0, 1.0, 0.4)
+
+    def solution(t, p):
+        return p[0] + p[1] * t
+
+    system = create_autonomous_ode(
+        parameters=VectorSpace("p", 2),
+        x0=x0,
+        xdot=xdot,
+        backend=variational_backend,
+    )
+
+    def loss(f, p_inner):
+        total_error = 0.0
+        for t_i in sample_times:
+            total_error += (solution(t_i, param) - f(t_i, p_inner)) ** 2
+        return total_error
+
+    callback = LossCheckingCallback(sample_times, solution, param)
+
+    problem = VariationalProblem(
+        loss=loss,
+        system=system,
+        parameters=[
+            BoundedVariable("offset", upper_bound=3, lower_bound=0.5, guess=2),
+            float(param[1]),
+        ],
+        t_final=1,
+        backend=variational_backend,
+    )
+    problem.transcription_options.interation_callback = callback
+
+    solution_out = problem()
+
+    assert solution_out.cost < 1e-6
+    assert callback.loss_differences
+    assert max(callback.loss_differences) < 1e-9
+
+
+def test_variational_iteration_callback_loss_matches_payload_each_step_until_completion(
+    variational_backend,
+):
+    def x0(p):
+        return p[0]
+
+    def xdot(x, p):
+        return p[1] * x
+
+    param = np.array([1.5, -0.75])
+    sample_times = np.array([0.0, 0.2, 0.5, 0.8, 1.0])
+
+    def solution(t, p):
+        return p[0] * np.exp(p[1] * t)
+
+    system = create_autonomous_ode(
+        parameters=VectorSpace("p", 2),
+        x0=x0,
+        xdot=xdot,
+        backend=variational_backend,
+    )
+
+    def loss(f, p_inner):
+        total_error = 0.0
+        for t_i in sample_times:
+            total_error += (solution(t_i, param) - f(t_i, p_inner)) ** 2
+        return total_error
+
+    callback = LossCheckingCallback(sample_times, solution, param)
+
+    problem = VariationalProblem(
+        loss=loss,
+        system=system,
+        parameters=[
+            BoundedVariable(
+                "initial", upper_bound=3.0, lower_bound=0.1, guess=2.8
+            ),
+            BoundedVariable(
+                "rate", upper_bound=1.0, lower_bound=-2.0, guess=0.8
+            ),
+        ],
+        t_final=1,
+        backend=variational_backend,
+    )
+    problem.transcription_options.initialise_near_guess = False
+    problem.transcription_options.optimiser_options = {"ipopt.max_iter": 50}
+    problem.transcription_options.interation_callback = callback
+
+    solution_out = problem()
+
+    assert solution_out.cost < 1e-6
+    assert abs(solution_out.parameter_solutions["initial"] - param[0]) < 1e-4
+    assert abs(solution_out.parameter_solutions["rate"] - param[1]) < 1e-4
+    assert len(callback.losses) > 1
+    assert max(callback.loss_differences) < 1e-9


### PR DESCRIPTION
## Summary
- add a CasADi iteration callback wrapper that rebuilds the current variational iterate payload
- wire callback support through the main NLP solver without attaching it to the warm-start initialiser
- add callback-focused tests covering per-step loss consistency and full-solve completion

## Testing
- python -m black --check src/coker/backends/casadi/variational_solver.py src/coker/dynamics/types.py tests/dynamical_systems/test_variational_solver_callback.py
- pytest tests/dynamical_systems/test_variational_solver_callback.py -q