### PR TITLE
Refactor and optimize coker backend workspace layers

### DIFF
--- a/docs/backend_architecture.rst
+++ b/docs/backend_architecture.rst
@@ -1,0 +1,30 @@
+Coker backend architecture
+==========================
+
+The coker backend lowers a traced function into a compact internal graph over a
+single contiguous workspace vector.
+
+At compile time, ``create_opgraph()`` in ``src/coker/backends/coker/core.py``
+walks the tape and assigns each value to a slice of that workspace. Inputs are
+packed by ``InputLayer`` in C order, and outputs are unpacked by
+``OutputLayer`` using the same layout.
+
+Runtime execution is a sequence of full-vector layers:
+
+- ``BilinearWorkspaceLayer`` applies a sparse affine/quadratic transform to the
+  whole workspace. This is used for bilinear-compatible algebra such as
+  ``ADD``, ``SUB``, ``NEG``, ``TRANSPOSE``, ``MUL``, ``MATMUL``, ``CROSS``, and
+  ``DOT``.
+- ``GenericVectorLayer`` handles non-bilinear work coordinate-by-coordinate.
+  It stores one op tuple per output coordinate and propagates both values and
+  tangents for ``push_forward``.
+
+Sparse layer parameters are stored with ``dok_ndarray``-backed
+``BilinearWeights`` rather than dense compiled matrices. The workspace itself
+remains a dense NumPy vector, so evaluation and forward-mode autodiff operate on
+simple contiguous arrays while layer metadata stays sparse.
+
+``SparseNet`` in ``src/coker/backends/coker/ast_preprocessing.py`` executes the
+layers and exposes both value evaluation and ``push_forward``. When a function
+contains ``FunctionSpace`` inputs or ``None`` outputs, the backend falls back to
+numpy lowering instead of building this static graph.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,12 @@ them efficiently on embedded or bare-metal hardware.
    getting_started
 
 .. toctree::
+   :maxdepth: 1
+   :caption: Internals
+
+   backend_architecture
+
+.. toctree::
    :maxdepth: 2
    :caption: API Reference
 

--- a/src/coker/backends/coker/ast_preprocessing.py
+++ b/src/coker/backends/coker/ast_preprocessing.py
@@ -146,7 +146,7 @@ def label_sources(
 class SparseNet:
     def __init__(
         self,
-        memory,
+        memory: MemorySpec,
         input_layer: InputLayer,
         output_layer: OutputLayer,
         intermediate_layers,
@@ -162,35 +162,25 @@ class SparseNet:
 
     def __call__(self, *args):
         workspace = self.apply_input_map(*args)
-
         for layer in self.intermediate_layers:
-            in_specs = layer.inputs()
-            (out_spec,) = layer.outputs()
-            out = layer(*[workspace[k] for k in in_specs])
-            workspace[out_spec] = np.asarray(out).flatten()
+            workspace = layer(workspace)
         return self.output_layer.call(workspace)
 
     def push_forward(self, *tangent_spaces):
-        n_args = len(self.input_layer.vec_to_arg_maps)
+        n_args = len(self.input_layer.input_specs)
         x, dx = tangent_spaces[0:n_args], tangent_spaces[n_args:]
         workspace = self.apply_input_map(*x)
         dworkspace = self.apply_input_map(*dx)
 
         for layer in self.intermediate_layers:
-            in_specs = layer.inputs()
-            (out_spec,) = layer.outputs()
-            x_i = [workspace[k] for k in in_specs]
-            dx_i = [dworkspace[k] for k in in_specs]
-            out, dout = layer.push_forward(*x_i, *dx_i)
-            workspace[out_spec] = out
-            dworkspace[out_spec] = dout
+            workspace, dworkspace = layer.push_forward(workspace, dworkspace)
 
         y = self.output_layer.call(workspace)
         dy = self.output_layer.call(dworkspace)
         return y, dy
 
-    def apply_input_map(self, *args) -> Dict[MemorySpec, np.ndarray]:
-        return {self.memory[0]: self.input_layer(*args)}
+    def apply_input_map(self, *args) -> np.ndarray:
+        return self.input_layer(*args)
 
-    def apply_output_map(self, context):
-        return self.output_layer.call(context)
+    def apply_output_map(self, workspace):
+        return self.output_layer.call(workspace)

--- a/src/coker/backends/coker/core.py
+++ b/src/coker/backends/coker/core.py
@@ -106,9 +106,13 @@ def _constant_array(value, shape: Tuple[int, ...]) -> np.ndarray:
     return np.array([value]).reshape(shape, order="C")
 
 
-def _constant_to_bw(memory: MemorySpec, value, shape: Tuple[int, ...]) -> BilinearWeights:
+def _constant_to_bw(
+    memory: MemorySpec, value, shape: Tuple[int, ...]
+) -> BilinearWeights:
     array = _constant_array(value, shape)
-    return BilinearWeights(memory, shape, constant=dok_ndarray.fromarray(array))
+    return BilinearWeights(
+        memory, shape, constant=dok_ndarray.fromarray(array)
+    )
 
 
 def _flatten_constant_refs(value, shape: Tuple[int, ...], add_constant):
@@ -139,14 +143,18 @@ def _append_bilinear_value(
         quadratic[target] = quadratic[target] + value
 
 
-def _build_opaque_operand(value, spec: MemorySpec | None, shape: Tuple[int, ...]):
+def _build_opaque_operand(
+    value, spec: MemorySpec | None, shape: Tuple[int, ...]
+):
     if spec is not None:
         return WorkspaceOperand(spec, shape)
     if isinstance(value, np.ndarray):
         stored = dok_ndarray.fromarray(np.reshape(value, shape, order="C"))
         return ConstantOperand(stored, shape)
     if scipy.sparse.issparse(value):
-        stored = dok_ndarray.fromarray(np.reshape(value.toarray(), shape, order="C"))
+        stored = dok_ndarray.fromarray(
+            np.reshape(value.toarray(), shape, order="C")
+        )
         return ConstantOperand(stored, shape)
     return ConstantOperand(value, shape)
 
@@ -176,7 +184,10 @@ def create_opgraph(function: Function):
 
     def extend_node_values(new_memory: MemorySpec):
         for node_idx, value in list(node_values.items()):
-            if isinstance(value, BilinearWeights) and value.memory != new_memory:
+            if (
+                isinstance(value, BilinearWeights)
+                and value.memory != new_memory
+            ):
                 node_values[node_idx] = value.extend_memory(new_memory)
 
     def queue_bilinear(idx: int, value: BilinearWeights):
@@ -202,11 +213,15 @@ def create_opgraph(function: Function):
         new_memory = MemorySpec(0, next_location)
         constant = dok_ndarray((next_location,))
         linear = dok_ndarray((next_location, old_memory.count))
-        quadratic = dok_ndarray((next_location, old_memory.count, old_memory.count))
+        quadratic = dok_ndarray(
+            (next_location, old_memory.count, old_memory.count)
+        )
         for i in range(current_size):
             linear[(i, i)] = 1
         for _, bw, _, spec in additions:
-            _append_bilinear_value(constant, linear, quadratic, spec.location, bw)
+            _append_bilinear_value(
+                constant, linear, quadratic, spec.location, bw
+            )
 
         weights = BilinearWeights(
             old_memory,
@@ -235,7 +250,8 @@ def create_opgraph(function: Function):
         next_memory = MemorySpec(0, current_size + output_count)
 
         layer_ops = [
-            (IDENTITY_OP, i, UNUSED_REF, UNUSED_REF) for i in range(current_size)
+            (IDENTITY_OP, i, UNUSED_REF, UNUSED_REF)
+            for i in range(current_size)
         ]
         constants: Dict[int, float] = {}
         next_constant = -1
@@ -270,9 +286,14 @@ def create_opgraph(function: Function):
                 for row in range(output_count)
             )
             scalar_lowered = True
-        elif isinstance(op, ConcatenateOP) and op.axis == 0 and all(
-            tape.dim[arg.index].is_scalar() or tape.dim[arg.index].is_vector()
-            for arg in args
+        elif (
+            isinstance(op, ConcatenateOP)
+            and op.axis == 0
+            and all(
+                tape.dim[arg.index].is_scalar()
+                or tape.dim[arg.index].is_vector()
+                for arg in args
+            )
         ):
             concatenated_refs = []
             for arg in args:
@@ -349,12 +370,17 @@ def create_opgraph(function: Function):
                 spec = node_specs.get(arg.index)
                 operand_specs.append(
                     _build_opaque_operand(
-                        node_values[arg.index], spec, _node_shape(tape.dim[arg.index])
+                        node_values[arg.index],
+                        spec,
+                        _node_shape(tape.dim[arg.index]),
                     )
                 )
             opaque_programs.append(
                 OpaqueProgram(
-                    output_spec.location, output_shape, op, tuple(operand_specs)
+                    output_spec.location,
+                    output_shape,
+                    op,
+                    tuple(operand_specs),
                 )
             )
             layer_ops.extend(
@@ -373,7 +399,9 @@ def create_opgraph(function: Function):
         current_size = next_memory.count
         extend_node_values(next_memory)
         node_specs[idx] = output_spec
-        node_values[idx] = BilinearWeights.project(next_memory, output_spec, output_shape)
+        node_values[idx] = BilinearWeights.project(
+            next_memory, output_spec, output_shape
+        )
 
     for idx in range(len(tape)):
         if idx in tape.input_indicies:
@@ -386,7 +414,9 @@ def create_opgraph(function: Function):
             continue
 
         operands = [node_values[a.index] for a in args]
-        if all(not isinstance(operand, BilinearWeights) for operand in operands):
+        if all(
+            not isinstance(operand, BilinearWeights) for operand in operands
+        ):
             node_values[idx] = numpy_backend.call(op, *operands)
             continue
 
@@ -408,9 +438,13 @@ def create_opgraph(function: Function):
         if isinstance(op, ReshapeOP):
             (arg_value,) = operands
             if isinstance(arg_value, BilinearWeights):
-                queue_bilinear(idx, arg_value.reshape(op.newshape, order=op.order))
+                queue_bilinear(
+                    idx, arg_value.reshape(op.newshape, order=op.order)
+                )
                 continue
-            node_values[idx] = np.reshape(arg_value, op.newshape, order=op.order)
+            node_values[idx] = np.reshape(
+                arg_value, op.newshape, order=op.order
+            )
             continue
 
         lower_generic(idx, op, args)
@@ -426,7 +460,9 @@ def create_opgraph(function: Function):
         else:
             queue_bilinear(
                 output.index,
-                _constant_to_bw(current_memory, value, _node_shape(output.dim)),
+                _constant_to_bw(
+                    current_memory, value, _node_shape(output.dim)
+                ),
             )
 
     flush_bilinear()

--- a/src/coker/backends/coker/core.py
+++ b/src/coker/backends/coker/core.py
@@ -1,18 +1,29 @@
-from typing import Tuple, Type, List, Dict
-from coker.algebra.kernel import Tracer, Function
-from coker.algebra.ops import OP
+from typing import Dict, List, Tuple, Type
+
+import numpy as np
+import scipy.sparse
+
 from coker.algebra.dimensions import FunctionSpace
-from coker.backends.backend import Backend, ArrayLike, get_backend_by_name
+from coker.algebra.kernel import Function, Tracer
+from coker.algebra.ops import ConcatenateOP, OP, ReshapeOP
+from coker.backends.backend import ArrayLike, Backend, get_backend_by_name
 from coker.backends.coker.ast_preprocessing import SparseNet
 from coker.backends.coker.layers import (
-    MemorySpec,
+    IDENTITY_OP,
+    OPAQUE_OP,
+    UNUSED_REF,
+    BilinearWorkspaceLayer,
+    ConstantOperand,
+    GenericVectorLayer,
     InputLayer,
+    OpaqueProgram,
     OutputLayer,
-    GenericLayerOP,
+    WorkspaceOperand,
 )
-from coker.backends.coker.weights import BilinearWeights
+from coker.backends.coker.memory import MemorySpec
 from coker.backends.coker.op_impl import ops
-import scipy.sparse
+from coker.backends.coker.sparse_tensor import dok_ndarray
+from coker.backends.coker.weights import BilinearWeights
 
 
 class CokerBackend(Backend):
@@ -32,12 +43,9 @@ class CokerBackend(Backend):
         pass
 
     def evaluate(self, function, inputs: ArrayLike):
-
         if all(o is None for o in function.output):
             return function.output
 
-        # Fall back to numpy for higher-order functions with
-        # FunctionSpace inputs.
         if any(
             isinstance(function.tape.dim[i], FunctionSpace)
             for i in function.tape.input_indicies
@@ -46,15 +54,12 @@ class CokerBackend(Backend):
             return numpy_backend.evaluate(function, inputs)
 
         g = create_opgraph(function)
-
         return [g(*inputs)]
 
     def reshape(self, array: ArrayLike, shape: Tuple[int, ...]) -> ArrayLike:
         raise NotImplementedError
 
     def lower(self, function: Function):
-        # FunctionSpace inputs and None outputs can't be lowered to a static
-        # graph; fall back to the numpy plan for those cases.
         if any(
             isinstance(function.tape.dim[i], FunctionSpace)
             for i in function.tape.input_indicies
@@ -71,7 +76,7 @@ class CokerBackend(Backend):
 
     def build_optimisation_problem(
         self,
-        cost: Tracer,  # cost
+        cost: Tracer,
         constraints: List[Tracer],
         parameters: List[Tracer],
         outputs: List[Tracer],
@@ -80,91 +85,354 @@ class CokerBackend(Backend):
         raise NotImplementedError
 
 
+def _node_shape(dim):
+    return dim.shape if hasattr(dim, "shape") else None
+
+
+def _as_numpy_value(value):
+    if scipy.sparse.issparse(value):
+        value = value.toarray()
+    if isinstance(value, np.ndarray):
+        return np.asarray(value)
+    if isinstance(value, (float, int, bool, np.bool_)):
+        return value
+    return value
+
+
+def _constant_array(value, shape: Tuple[int, ...]) -> np.ndarray:
+    value = _as_numpy_value(value)
+    if isinstance(value, np.ndarray):
+        return np.reshape(value, shape, order="C")
+    return np.array([value]).reshape(shape, order="C")
+
+
+def _constant_to_bw(memory: MemorySpec, value, shape: Tuple[int, ...]) -> BilinearWeights:
+    array = _constant_array(value, shape)
+    return BilinearWeights(memory, shape, constant=dok_ndarray.fromarray(array))
+
+
+def _flatten_constant_refs(value, shape: Tuple[int, ...], add_constant):
+    flat = _constant_array(value, shape).reshape(-1, order="C")
+    if flat.size == 1:
+        return add_constant(flat[0])
+    return [add_constant(v) for v in flat]
+
+
+def _append_bilinear_value(
+    constant: dok_ndarray,
+    linear: dok_ndarray,
+    quadratic: dok_ndarray,
+    start: int,
+    bw: BilinearWeights,
+):
+    for key, value in bw.constant.keys.items():
+        row = np.ravel_multi_index(key, bw.shape, order="C")
+        target = (start + row,)
+        constant[target] = constant[target] + value
+    for key, value in bw.linear.keys.items():
+        row = np.ravel_multi_index(key[:-1], bw.shape, order="C")
+        target = (start + row, key[-1])
+        linear[target] = linear[target] + value
+    for key, value in bw.quadratic.keys.items():
+        row = np.ravel_multi_index(key[:-2], bw.shape, order="C")
+        target = (start + row, key[-2], key[-1])
+        quadratic[target] = quadratic[target] + value
+
+
+def _build_opaque_operand(value, spec: MemorySpec | None, shape: Tuple[int, ...]):
+    if spec is not None:
+        return WorkspaceOperand(spec, shape)
+    if isinstance(value, np.ndarray):
+        stored = dok_ndarray.fromarray(np.reshape(value, shape, order="C"))
+        return ConstantOperand(stored, shape)
+    if scipy.sparse.issparse(value):
+        stored = dok_ndarray.fromarray(np.reshape(value.toarray(), shape, order="C"))
+        return ConstantOperand(stored, shape)
+    return ConstantOperand(value, shape)
+
+
 def create_opgraph(function: Function):
     tape = function.tape
+    numpy_backend = get_backend_by_name("numpy", set_current=False)
 
     input_layer = InputLayer()
+    node_values = {}
+    node_specs: Dict[int, MemorySpec] = {}
+
     for i in tape.input_indicies:
-        input_layer.add_input(tape.dim[i])
+        input_idx = input_layer.add_input(tape.dim[i])
+        spec, _ = input_layer.input_specs[input_idx]
+        node_specs[i] = spec
 
-    input_memory = MemorySpec(location=0, count=input_layer.dimension)
-
-    node_values = {
-        i: BilinearWeights(
-            linear=input_layer.get_projection(i),
-            memory=input_memory,
-            shape=tape.dim[i].shape,
+    current_memory = MemorySpec(location=0, count=input_layer.dimension)
+    for i in tape.input_indicies:
+        node_values[i] = BilinearWeights.project(
+            current_memory, node_specs[i], _node_shape(tape.dim[i])
         )
-        for i in tape.input_indicies
-    }
 
     layers = []
-    next_location = input_layer.dimension
-    output_indices = {
-        output.index for output in function.output if output is not None
-    }
-    numpy_backend = get_backend_by_name("numpy", set_current=False)
+    current_size = input_layer.dimension
+    pending_bilinear: List[int] = []
+
+    def extend_node_values(new_memory: MemorySpec):
+        for node_idx, value in list(node_values.items()):
+            if isinstance(value, BilinearWeights) and value.memory != new_memory:
+                node_values[node_idx] = value.extend_memory(new_memory)
+
+    def queue_bilinear(idx: int, value: BilinearWeights):
+        node_values[idx] = value
+        if idx not in pending_bilinear and idx not in node_specs:
+            pending_bilinear.append(idx)
+
+    def flush_bilinear():
+        nonlocal current_memory, current_size
+        if not pending_bilinear:
+            return
+
+        old_memory = current_memory
+        additions = []
+        next_location = current_size
+        for idx in pending_bilinear:
+            bw = node_values[idx]
+            shape = _node_shape(tape.dim[idx])
+            spec = MemorySpec(next_location, tape.dim[idx].flat())
+            additions.append((idx, bw, shape, spec))
+            next_location += spec.count
+
+        new_memory = MemorySpec(0, next_location)
+        constant = dok_ndarray((next_location,))
+        linear = dok_ndarray((next_location, old_memory.count))
+        quadratic = dok_ndarray((next_location, old_memory.count, old_memory.count))
+        for i in range(current_size):
+            linear[(i, i)] = 1
+        for _, bw, _, spec in additions:
+            _append_bilinear_value(constant, linear, quadratic, spec.location, bw)
+
+        weights = BilinearWeights(
+            old_memory,
+            (next_location,),
+            constant=constant,
+            linear=linear,
+            quadratic=quadratic,
+        )
+        layers.append(BilinearWorkspaceLayer(old_memory, new_memory, weights))
+
+        current_memory = new_memory
+        current_size = next_location
+        extend_node_values(new_memory)
+        for idx, _, shape, spec in additions:
+            node_specs[idx] = spec
+            node_values[idx] = BilinearWeights.project(new_memory, spec, shape)
+        pending_bilinear.clear()
+
+    def lower_generic(idx: int, op, args):
+        nonlocal current_memory, current_size
+        flush_bilinear()
+
+        output_shape = _node_shape(tape.dim[idx])
+        output_count = tape.dim[idx].flat()
+        output_spec = MemorySpec(current_size, output_count)
+        next_memory = MemorySpec(0, current_size + output_count)
+
+        layer_ops = [
+            (IDENTITY_OP, i, UNUSED_REF, UNUSED_REF) for i in range(current_size)
+        ]
+        constants: Dict[int, float] = {}
+        next_constant = -1
+
+        def add_constant(value):
+            nonlocal next_constant
+            ref = next_constant
+            constants[ref] = float(value)
+            next_constant -= 1
+            return ref
+
+        def refs_for_arg(arg):
+            arg_shape = _node_shape(tape.dim[arg.index])
+            if arg.index in node_specs:
+                spec = node_specs[arg.index]
+                if spec.count == 1:
+                    return spec.location
+                return [spec.location + i for i in range(spec.count)]
+            return _flatten_constant_refs(
+                node_values[arg.index], arg_shape, add_constant
+            )
+
+        def row_ref(refs, row: int):
+            return refs if isinstance(refs, int) else refs[row]
+
+        scalar_lowered = False
+        if isinstance(op, ReshapeOP):
+            (arg,) = args
+            refs = refs_for_arg(arg)
+            layer_ops.extend(
+                (IDENTITY_OP, row_ref(refs, row), UNUSED_REF, UNUSED_REF)
+                for row in range(output_count)
+            )
+            scalar_lowered = True
+        elif isinstance(op, ConcatenateOP) and op.axis == 0 and all(
+            tape.dim[arg.index].is_scalar() or tape.dim[arg.index].is_vector()
+            for arg in args
+        ):
+            concatenated_refs = []
+            for arg in args:
+                refs = refs_for_arg(arg)
+                if isinstance(refs, int):
+                    concatenated_refs.append(refs)
+                else:
+                    concatenated_refs.extend(refs)
+            layer_ops.extend(
+                (IDENTITY_OP, ref, UNUSED_REF, UNUSED_REF)
+                for ref in concatenated_refs
+            )
+            scalar_lowered = True
+        elif op in {
+            OP.SIN,
+            OP.COS,
+            OP.TAN,
+            OP.EXP,
+            OP.SQRT,
+            OP.LOG,
+            OP.NEG,
+            OP.ABS,
+        }:
+            (arg,) = args
+            refs = refs_for_arg(arg)
+            layer_ops.extend(
+                (op, row_ref(refs, row), UNUSED_REF, UNUSED_REF)
+                for row in range(output_count)
+            )
+            scalar_lowered = True
+        elif op in {
+            OP.ADD,
+            OP.SUB,
+            OP.MUL,
+            OP.DIV,
+            OP.PWR,
+            OP.INT_PWR,
+            OP.ARCTAN2,
+            OP.EQUAL,
+            OP.LESS_THAN,
+            OP.LESS_EQUAL,
+        }:
+            lhs_refs = refs_for_arg(args[0])
+            rhs_refs = refs_for_arg(args[1])
+            layer_ops.extend(
+                (
+                    op,
+                    row_ref(lhs_refs, row),
+                    row_ref(rhs_refs, row),
+                    UNUSED_REF,
+                )
+                for row in range(output_count)
+            )
+            scalar_lowered = True
+        elif op == OP.CASE:
+            cond_refs = refs_for_arg(args[0])
+            true_refs = refs_for_arg(args[1])
+            false_refs = refs_for_arg(args[2])
+            layer_ops.extend(
+                (
+                    op,
+                    row_ref(cond_refs, 0),
+                    row_ref(true_refs, row),
+                    row_ref(false_refs, row),
+                )
+                for row in range(output_count)
+            )
+            scalar_lowered = True
+
+        opaque_programs: List[OpaqueProgram] = []
+        if not scalar_lowered:
+            operand_specs = []
+            for arg in args:
+                spec = node_specs.get(arg.index)
+                operand_specs.append(
+                    _build_opaque_operand(
+                        node_values[arg.index], spec, _node_shape(tape.dim[arg.index])
+                    )
+                )
+            opaque_programs.append(
+                OpaqueProgram(
+                    output_spec.location, output_shape, op, tuple(operand_specs)
+                )
+            )
+            layer_ops.extend(
+                (OPAQUE_OP, 0, row, UNUSED_REF) for row in range(output_count)
+            )
+
+        layer = GenericVectorLayer(
+            current_memory,
+            next_memory,
+            layer_ops,
+            constants=constants,
+            opaque_programs=opaque_programs,
+        )
+        layers.append(layer)
+        current_memory = next_memory
+        current_size = next_memory.count
+        extend_node_values(next_memory)
+        node_specs[idx] = output_spec
+        node_values[idx] = BilinearWeights.project(next_memory, output_spec, output_shape)
 
     for idx in range(len(tape)):
         if idx in tape.input_indicies:
             continue
 
         op, *args = tape.nodes[idx]
-
         if op == OP.VALUE:
             (constant_value,) = args
-            if scipy.sparse.issparse(constant_value):
-                constant_value = constant_value.toarray()
-            node_values[idx] = constant_value
+            node_values[idx] = _as_numpy_value(constant_value)
             continue
 
         operands = [node_values[a.index] for a in args]
-        # Collapse constant BilinearWeights to plain numpy arrays so the
-        # constant-fold path below can consume them without needing a layer.
-        operands = [
-            (
-                o.constant.toarray().reshape(o.shape)
-                if isinstance(o, BilinearWeights) and o.is_constant
-                else o
-            )
-            for o in operands
-        ]
-        bw_operands = [
-            operand
-            for operand in operands
-            if isinstance(operand, BilinearWeights)
-        ]
-
-        if not bw_operands:
+        if all(not isinstance(operand, BilinearWeights) for operand in operands):
             node_values[idx] = numpy_backend.call(op, *operands)
             continue
 
-        if idx not in output_indices and op in ops:
-            memories = {id(operand.memory) for operand in bw_operands}
-            if len(memories) == 1:
+        if op in ops:
+            memories = {
+                id(operand.memory)
+                for operand in operands
+                if isinstance(operand, BilinearWeights)
+            }
+            if len(memories) <= 1:
                 try:
                     result = ops[op](*operands)
                     if isinstance(result, BilinearWeights):
-                        node_values[idx] = result
+                        queue_bilinear(idx, result)
                         continue
                 except (AssertionError, TypeError, NotImplementedError):
                     pass
 
-        count = tape.dim[idx].flat()
-        mem = MemorySpec(location=next_location, count=count)
-        next_location += count
-        compiled_operands = [
-            o.compile() if isinstance(o, BilinearWeights) else o
-            for o in operands
-        ]
-        layers.append(GenericLayerOP(mem, op, *compiled_operands))
-        shape = tape.dim[idx].shape or (1,)
-        node_values[idx] = BilinearWeights.reshape_identity(
-            memory=mem, shape=shape
-        )
+        if isinstance(op, ReshapeOP):
+            (arg_value,) = operands
+            if isinstance(arg_value, BilinearWeights):
+                queue_bilinear(idx, arg_value.reshape(op.newshape, order=op.order))
+                continue
+            node_values[idx] = np.reshape(arg_value, op.newshape, order=op.order)
+            continue
+
+        lower_generic(idx, op, args)
+
+    for output in function.output:
+        if output is None:
+            continue
+        if output.index in node_specs:
+            continue
+        value = node_values[output.index]
+        if isinstance(value, BilinearWeights):
+            queue_bilinear(output.index, value)
+        else:
+            queue_bilinear(
+                output.index,
+                _constant_to_bw(current_memory, value, _node_shape(output.dim)),
+            )
+
+    flush_bilinear()
 
     output_layer = OutputLayer()
     for output in function.output:
-        output_layer.add_output(node_values[output.index].memory, output.dim)
+        output_layer.add_output(node_specs[output.index], output.dim)
 
-    return SparseNet([input_memory], input_layer, output_layer, layers)
+    return SparseNet(current_memory, input_layer, output_layer, layers)

--- a/src/coker/backends/coker/layers.py
+++ b/src/coker/backends/coker/layers.py
@@ -137,7 +137,12 @@ class OutputLayer:
 
 
 class BilinearWorkspaceLayer:
-    def __init__(self, memory_in: MemorySpec, memory_out: MemorySpec, weights: BilinearWeights):
+    def __init__(
+        self,
+        memory_in: MemorySpec,
+        memory_out: MemorySpec,
+        weights: BilinearWeights,
+    ):
         self.memory_in = memory_in
         self.memory_out = memory_out
         self.weights = weights
@@ -186,18 +191,20 @@ class GenericVectorLayer:
         opaque_rows = {
             row
             for program in self.opaque_programs
-            for row in range(program.row_start, program.row_start + program.row_count)
+            for row in range(
+                program.row_start, program.row_start + program.row_count
+            )
         }
         for row, (op, first, second, third) in enumerate(self.ops):
             if row in opaque_rows:
                 continue
-            values[row], _ = self._eval_scalar_row(
-                op, first, second, third, workspace, np.zeros_like(workspace)
+            values[row] = self._eval_scalar_value(
+                op, first, second, third, workspace
             )
         for program in self.opaque_programs:
-            flat = np.asarray(self._eval_opaque_value(program, workspace)).reshape(
-                -1, order="C"
-            )
+            flat = np.asarray(
+                self._eval_opaque_value(program, workspace)
+            ).reshape(-1, order="C")
             start = program.row_start
             stop = start + program.row_count
             values[start:stop] = flat
@@ -212,7 +219,9 @@ class GenericVectorLayer:
         opaque_rows = {
             row
             for program in self.opaque_programs
-            for row in range(program.row_start, program.row_start + program.row_count)
+            for row in range(
+                program.row_start, program.row_start + program.row_count
+            )
         }
 
         for row, (op, first, second, third) in enumerate(self.ops):
@@ -223,7 +232,9 @@ class GenericVectorLayer:
             )
 
         for program in self.opaque_programs:
-            result, dresult = self._eval_opaque_program(program, workspace, dworkspace)
+            result, dresult = self._eval_opaque_program(
+                program, workspace, dworkspace
+            )
             flat = np.asarray(result).reshape(-1, order="C")
             dflat = np.asarray(dresult).reshape(-1, order="C")
             start = program.row_start
@@ -243,24 +254,95 @@ class GenericVectorLayer:
             return float(dworkspace[index])
         return 0.0
 
-    def _eval_scalar_row(self, op, first, second, third, workspace, dworkspace):
+    def _eval_scalar_value(self, op, first, second, third, workspace):
         a = (
-            self._resolve_scalar(first, workspace) if first != UNUSED_REF else None
+            self._resolve_scalar(first, workspace)
+            if first != UNUSED_REF
+            else None
         )
         b = (
-            self._resolve_scalar(second, workspace) if second != UNUSED_REF else None
+            self._resolve_scalar(second, workspace)
+            if second != UNUSED_REF
+            else None
         )
         c = (
-            self._resolve_scalar(third, workspace) if third != UNUSED_REF else None
+            self._resolve_scalar(third, workspace)
+            if third != UNUSED_REF
+            else None
+        )
+
+        if op == IDENTITY_OP or op == CONSTANT_OP:
+            return a
+        if op == OP.SIN:
+            return np.sin(a)
+        if op == OP.COS:
+            return np.cos(a)
+        if op == OP.TAN:
+            return np.tan(a)
+        if op == OP.EXP:
+            return np.exp(a)
+        if op == OP.SQRT:
+            return np.sqrt(a)
+        if op == OP.LOG:
+            return np.log(a)
+        if op == OP.NEG:
+            return -a
+        if op == OP.ABS:
+            return np.abs(a)
+        if op == OP.ADD:
+            return a + b
+        if op == OP.SUB:
+            return a - b
+        if op == OP.MUL:
+            return a * b
+        if op == OP.DIV:
+            return scalar_divide(a, b)
+        if op == OP.PWR or op == OP.INT_PWR:
+            return np.power(a, b)
+        if op == OP.ARCTAN2:
+            return np.arctan2(a, b)
+        if op == OP.EQUAL:
+            return float(a == b)
+        if op == OP.LESS_THAN:
+            return float(a < b)
+        if op == OP.LESS_EQUAL:
+            return float(a <= b)
+        if op == OP.CASE:
+            return b if bool(a) else c
+        raise NotImplementedError(f"Unsupported scalar op {op}")
+
+    def _eval_scalar_row(
+        self, op, first, second, third, workspace, dworkspace
+    ):
+        a = (
+            self._resolve_scalar(first, workspace)
+            if first != UNUSED_REF
+            else None
+        )
+        b = (
+            self._resolve_scalar(second, workspace)
+            if second != UNUSED_REF
+            else None
+        )
+        c = (
+            self._resolve_scalar(third, workspace)
+            if third != UNUSED_REF
+            else None
         )
         da = (
-            self._resolve_tangent(first, dworkspace) if first != UNUSED_REF else 0.0
+            self._resolve_tangent(first, dworkspace)
+            if first != UNUSED_REF
+            else 0.0
         )
         db = (
-            self._resolve_tangent(second, dworkspace) if second != UNUSED_REF else 0.0
+            self._resolve_tangent(second, dworkspace)
+            if second != UNUSED_REF
+            else 0.0
         )
         dc = (
-            self._resolve_tangent(third, dworkspace) if third != UNUSED_REF else 0.0
+            self._resolve_tangent(third, dworkspace)
+            if third != UNUSED_REF
+            else 0.0
         )
 
         if op == IDENTITY_OP:
@@ -315,10 +397,13 @@ class GenericVectorLayer:
             return c, dc
         raise NotImplementedError(f"Unsupported scalar op {op}")
 
-    def _materialize_operand(self, operand: ArrayOperand, workspace: np.ndarray):
+    def _materialize_operand(
+        self, operand: ArrayOperand, workspace: np.ndarray
+    ):
         if isinstance(operand, WorkspaceOperand):
             raw = workspace[
-                operand.spec.location : operand.spec.location + operand.spec.count
+                operand.spec.location : operand.spec.location
+                + operand.spec.count
             ]
             return np.reshape(raw, operand.shape, order="C")
         value = operand.value
@@ -326,17 +411,23 @@ class GenericVectorLayer:
             return np.reshape(value.toarray(), operand.shape, order="C")
         return value
 
-    def _eval_opaque_value(self, program: OpaqueProgram, workspace: np.ndarray):
+    def _eval_opaque_value(
+        self, program: OpaqueProgram, workspace: np.ndarray
+    ):
         backend = get_backend_by_name("numpy", set_current=False)
         values = [
-            self._materialize_operand(operand, workspace) for operand in program.operands
+            self._materialize_operand(operand, workspace)
+            for operand in program.operands
         ]
         return backend.call(program.op, *values)
 
-    def _materialize_tangent(self, operand: ArrayOperand, dworkspace: np.ndarray):
+    def _materialize_tangent(
+        self, operand: ArrayOperand, dworkspace: np.ndarray
+    ):
         if isinstance(operand, WorkspaceOperand):
             raw = dworkspace[
-                operand.spec.location : operand.spec.location + operand.spec.count
+                operand.spec.location : operand.spec.location
+                + operand.spec.count
             ]
             return np.reshape(raw, operand.shape, order="C")
         value = operand.value
@@ -349,10 +440,16 @@ class GenericVectorLayer:
         return 0.0
 
     def _eval_opaque_program(
-        self, program: OpaqueProgram, workspace: np.ndarray, dworkspace: np.ndarray
+        self,
+        program: OpaqueProgram,
+        workspace: np.ndarray,
+        dworkspace: np.ndarray,
     ):
         backend = get_backend_by_name("numpy", set_current=False)
-        values = [self._materialize_operand(operand, workspace) for operand in program.operands]
+        values = [
+            self._materialize_operand(operand, workspace)
+            for operand in program.operands
+        ]
 
         if program.op == OP.EVALUATE and isinstance(values[0], Function):
             from coker.backends.coker.core import create_opgraph
@@ -367,7 +464,8 @@ class GenericVectorLayer:
 
         result = backend.call(program.op, *values)
         tangents = [
-            self._materialize_tangent(operand, dworkspace) for operand in program.operands
+            self._materialize_tangent(operand, dworkspace)
+            for operand in program.operands
         ]
 
         linear_like = program.op in {OP.TRANSPOSE}
@@ -375,4 +473,6 @@ class GenericVectorLayer:
             tangent = backend.call(program.op, *tangents)
             return result, tangent
 
-        raise NotImplementedError(f"push_forward not implemented for opaque op {program.op}")
+        raise NotImplementedError(
+            f"push_forward not implemented for opaque op {program.op}"
+        )

--- a/src/coker/backends/coker/layers.py
+++ b/src/coker/backends/coker/layers.py
@@ -1,23 +1,57 @@
-from typing import Dict, List, Set, Tuple
+from dataclasses import dataclass
+from typing import Dict, List, Sequence, Tuple, Union
 
 import numpy as np
 
 from coker.algebra.dimensions import Dimension
-from coker.algebra.kernel import scalar_types
+from coker.algebra.kernel import Function, scalar_types
 from coker.algebra.ops import OP
 from coker.backends import get_backend_by_name
 from coker.backends.coker.memory import MemorySpec
 from coker.backends.coker.sparse_tensor import dok_ndarray
-from coker.backends.coker.weights import BilinearWeights, _CompiledBW
+from coker.backends.coker.weights import BilinearWeights
 
-_AnyBW = (BilinearWeights, _CompiledBW)
+IDENTITY_OP = "identity"
+CONSTANT_OP = "constant"
+OPAQUE_OP = "opaque"
+UNUSED_REF = -(1 << 30)
+
+
+StoredConstant = Union[float, int, bool, dok_ndarray, Function, object]
+
+
+@dataclass(frozen=True)
+class WorkspaceOperand:
+    spec: MemorySpec
+    shape: Tuple[int, ...]
+
+
+@dataclass(frozen=True)
+class ConstantOperand:
+    value: StoredConstant
+    shape: Tuple[int, ...] | None
+
+
+@dataclass(frozen=True)
+class OpaqueProgram:
+    row_start: int
+    shape: Tuple[int, ...]
+    op: object
+    operands: Tuple[Union[WorkspaceOperand, ConstantOperand], ...]
+
+    @property
+    def row_count(self) -> int:
+        return int(np.prod(self.shape))
+
+
+ArrayOperand = Union[WorkspaceOperand, ConstantOperand]
 
 
 def vec(item):
     if isinstance(item, list):
         item = np.array(item)
     if isinstance(item, np.ndarray):
-        return item.flatten(order="F")
+        return np.asarray(item).reshape(-1, order="C")
     if isinstance(item, scalar_types):
         return np.array([item])
     raise NotImplementedError(type(item))
@@ -25,178 +59,320 @@ def vec(item):
 
 class InputLayer:
     def __init__(self):
-        """maps such that arg_i = map_i(x)
-
-        - For scalars; map_i is a linear operator
-        - For vector; map_i is a matrix
-
-
-        """
-        self.vec_to_arg_maps: List[Set[Tuple[int, ...]]] = []
-        self.out_shape = []
+        self.input_specs: List[Tuple[MemorySpec, Tuple[int, ...]]] = []
         self.dimension = 0
 
     def add_input(self, dim: Dimension) -> int:
-
-        idx = len(self.vec_to_arg_maps)
-        if dim.is_scalar():
-            self.vec_to_arg_maps.append({(0, self.dimension)})
-            self.dimension += 1
-            self.out_shape.append((1,))
-        else:
-            basis = set()
-            for i, idx in enumerate(dim.index_iterator(row_major=False)):
-                # for example, a vector would have an index tuple
-                # of idx = (row, ) so the basis becomes (row, d).
-                # We interpret this as a matrix
-                # For a matrix, we have bases (row, col, d)
-
-                basis.add((*idx, self.dimension))
-                self.dimension += 1
-            self.vec_to_arg_maps.append(basis)
-            self.out_shape.append((*dim,))
-
+        idx = len(self.input_specs)
+        shape = dim.shape
+        count = dim.flat()
+        spec = MemorySpec(self.dimension, count)
+        self.input_specs.append((spec, shape))
+        self.dimension += count
         return idx
 
     def get_projection(self, arg: int):
-        # return a matrix that maps
-        # M: vec(x) -> arg_i
-
-        nzeros = self.vec_to_arg_maps[arg]
-        shape = (*self.out_shape[arg], self.dimension)
-        m = dok_ndarray(shape)
-        for idx in nzeros:
-            m[idx] = 1
+        spec, shape = self.input_specs[arg]
+        m = dok_ndarray((*shape, self.dimension))
+        for offset in range(spec.count):
+            idx = np.unravel_index(offset, shape, order="C")
+            m[(*idx, spec.location + offset)] = 1
         return m
 
     def __call__(self, *args):
-        assert len(args) == len(self.vec_to_arg_maps)
-
-        x = np.concatenate([vec(a) for a in args])
-        return x
+        assert len(args) == len(self.input_specs)
+        if not args:
+            return np.zeros((0,), dtype=float)
+        return np.concatenate([vec(a) for a in args])
 
     def forwards(self, *tangent_space, y=None):
-        r"""Reverse mode autodiff
-
-        Here, :math:`y = \sum_j P_j x_j$`
-
-        so  dy = \sum P_j dx_j
-
-        """
-        n_args = len(self.vec_to_arg_maps)
+        n_args = len(self.input_specs)
         assert len(tangent_space) == 2 * n_args
         dx = tangent_space[n_args : 2 * n_args]
-
+        if not dx:
+            return np.zeros((0,), dtype=float)
         return np.concatenate([vec(dx_i) for dx_i in dx])
 
 
+def scalar_divide(num: float, den: float) -> float:
+    if den == 0:
+        return float("nan")
+    return float(np.divide(num, den))
+
+
 def to_float(x):
-    if isinstance(x, (float, int)):
+    if isinstance(x, (float, int, bool, np.bool_)):
         return float(x)
 
     assert isinstance(x, np.ndarray)
-    x_out = x.flatten()
+    x_out = x.reshape(-1, order="C")
     assert x_out.shape == (1,)
-    return x_out[0]
+    value = x_out[0]
+    if isinstance(value, (bool, np.bool_)):
+        return bool(value)
+    return float(value)
 
 
 class OutputLayer:
-
     def __init__(self):
-        self.outputs = {}
+        self.outputs: List[Tuple[MemorySpec, Dimension]] = []
 
     def inputs(self):
-        return list(self.outputs.keys())
+        return [memory for memory, _ in self.outputs]
 
     def add_output(self, memory: MemorySpec, shape: Dimension):
-        assert memory not in self.outputs
-        if shape.dim is None:
-            self.outputs[memory] = to_float
-            return
+        self.outputs.append((memory, shape))
 
-        def shape_fn(array):
-            return np.reshape(array, shape.dim)
-
-        self.outputs[memory] = shape_fn
-
-    def call(self, context: Dict[MemorySpec, np.ndarray]):
-        result = [f(context[k]) for k, f in self.outputs.items()]
+    def call(self, workspace: np.ndarray):
+        result = []
+        for memory, shape in self.outputs:
+            raw = workspace[memory.location : memory.location + memory.count]
+            if shape.dim is None:
+                result.append(to_float(raw))
+            else:
+                result.append(np.reshape(raw, shape.dim, order="C"))
         if len(result) == 1:
             return result[0]
         return result
 
 
-class GenericLayerOP:
-    def __init__(self, output, op, *weights):
-        self.op = op
+class BilinearWorkspaceLayer:
+    def __init__(self, memory_in: MemorySpec, memory_out: MemorySpec, weights: BilinearWeights):
+        self.memory_in = memory_in
+        self.memory_out = memory_out
         self.weights = weights
-        self.output = output
-
-        assert all(
-            isinstance(w, (*_AnyBW, np.ndarray, int, float, bool))
-            for w in weights
-        ), f"Unkown type in {weights}"
 
     def inputs(self) -> List[MemorySpec]:
-        return [w.memory for w in self.weights if isinstance(w, _AnyBW)]
+        return [self.memory_in]
 
     def outputs(self) -> List[MemorySpec]:
-        return [self.output]
+        return [self.memory_out]
 
-    def __call__(self, *x):
+    def __call__(self, workspace: np.ndarray) -> np.ndarray:
+        return np.asarray(self.weights(workspace)).reshape(-1, order="C")
+
+    def push_forward(self, workspace: np.ndarray, dworkspace: np.ndarray):
+        y, dy = self.weights.push_forwards(workspace, dworkspace)
+        return (
+            np.asarray(y).reshape(-1, order="C"),
+            np.asarray(dy).reshape(-1, order="C"),
+        )
+
+
+class GenericVectorLayer:
+    def __init__(
+        self,
+        memory_in: MemorySpec,
+        memory_out: MemorySpec,
+        ops: Sequence[Tuple[object, int, int, int]],
+        constants: Dict[int, float] | None = None,
+        opaque_programs: Sequence[OpaqueProgram] | None = None,
+    ):
+        self.memory_in = memory_in
+        self.memory_out = memory_out
+        self.ops = list(ops)
+        self.constants = constants or {}
+        self.opaque_programs = list(opaque_programs or [])
+
+    def inputs(self) -> List[MemorySpec]:
+        return [self.memory_in]
+
+    def outputs(self) -> List[MemorySpec]:
+        return [self.memory_out]
+
+    def __call__(self, workspace: np.ndarray) -> np.ndarray:
+        workspace = np.asarray(workspace).reshape(-1, order="C")
+        values = np.empty(self.memory_out.count, dtype=float)
+        opaque_rows = {
+            row
+            for program in self.opaque_programs
+            for row in range(program.row_start, program.row_start + program.row_count)
+        }
+        for row, (op, first, second, third) in enumerate(self.ops):
+            if row in opaque_rows:
+                continue
+            values[row], _ = self._eval_scalar_row(
+                op, first, second, third, workspace, np.zeros_like(workspace)
+            )
+        for program in self.opaque_programs:
+            flat = np.asarray(self._eval_opaque_value(program, workspace)).reshape(
+                -1, order="C"
+            )
+            start = program.row_start
+            stop = start + program.row_count
+            values[start:stop] = flat
+        return values
+
+    def push_forward(self, workspace: np.ndarray, dworkspace: np.ndarray):
+        workspace = np.asarray(workspace).reshape(-1, order="C")
+        dworkspace = np.asarray(dworkspace).reshape(-1, order="C")
+        values = np.empty(self.memory_out.count, dtype=float)
+        tangents = np.zeros(self.memory_out.count, dtype=float)
+
+        opaque_rows = {
+            row
+            for program in self.opaque_programs
+            for row in range(program.row_start, program.row_start + program.row_count)
+        }
+
+        for row, (op, first, second, third) in enumerate(self.ops):
+            if row in opaque_rows:
+                continue
+            values[row], tangents[row] = self._eval_scalar_row(
+                op, first, second, third, workspace, dworkspace
+            )
+
+        for program in self.opaque_programs:
+            result, dresult = self._eval_opaque_program(program, workspace, dworkspace)
+            flat = np.asarray(result).reshape(-1, order="C")
+            dflat = np.asarray(dresult).reshape(-1, order="C")
+            start = program.row_start
+            stop = start + program.row_count
+            values[start:stop] = flat
+            tangents[start:stop] = dflat
+
+        return values, tangents
+
+    def _resolve_scalar(self, index: int, workspace: np.ndarray) -> float:
+        if index >= 0:
+            return float(workspace[index])
+        return float(self.constants[index])
+
+    def _resolve_tangent(self, index: int, dworkspace: np.ndarray) -> float:
+        if index >= 0:
+            return float(dworkspace[index])
+        return 0.0
+
+    def _eval_scalar_row(self, op, first, second, third, workspace, dworkspace):
+        a = (
+            self._resolve_scalar(first, workspace) if first != UNUSED_REF else None
+        )
+        b = (
+            self._resolve_scalar(second, workspace) if second != UNUSED_REF else None
+        )
+        c = (
+            self._resolve_scalar(third, workspace) if third != UNUSED_REF else None
+        )
+        da = (
+            self._resolve_tangent(first, dworkspace) if first != UNUSED_REF else 0.0
+        )
+        db = (
+            self._resolve_tangent(second, dworkspace) if second != UNUSED_REF else 0.0
+        )
+        dc = (
+            self._resolve_tangent(third, dworkspace) if third != UNUSED_REF else 0.0
+        )
+
+        if op == IDENTITY_OP:
+            return a, da
+        if op == CONSTANT_OP:
+            return a, 0.0
+        if op == OP.SIN:
+            return np.sin(a), np.cos(a) * da
+        if op == OP.COS:
+            return np.cos(a), -np.sin(a) * da
+        if op == OP.TAN:
+            return np.tan(a), da / (np.cos(a) ** 2)
+        if op == OP.EXP:
+            value = np.exp(a)
+            return value, value * da
+        if op == OP.SQRT:
+            value = np.sqrt(a)
+            return value, da / (2.0 * value)
+        if op == OP.LOG:
+            return np.log(a), da / a
+        if op == OP.NEG:
+            return -a, -da
+        if op == OP.ABS:
+            return np.abs(a), np.sign(a) * da
+        if op == OP.ADD:
+            return a + b, da + db
+        if op == OP.SUB:
+            return a - b, da - db
+        if op == OP.MUL:
+            return a * b, b * da + a * db
+        if op == OP.DIV:
+            if b == 0:
+                return float("nan"), float("nan")
+            return scalar_divide(a, b), scalar_divide(da * b - a * db, b * b)
+        if op == OP.PWR or op == OP.INT_PWR:
+            value = np.power(a, b)
+            if a == 0:
+                return value, 0.0
+            return value, value * (db * np.log(a) + (b * da / a))
+        if op == OP.ARCTAN2:
+            denom = a * a + b * b
+            return np.arctan2(a, b), (b * da - a * db) / denom
+        if op == OP.EQUAL:
+            return float(a == b), 0.0
+        if op == OP.LESS_THAN:
+            return float(a < b), 0.0
+        if op == OP.LESS_EQUAL:
+            return float(a <= b), 0.0
+        if op == OP.CASE:
+            if bool(a):
+                return b, db
+            return c, dc
+        raise NotImplementedError(f"Unsupported scalar op {op}")
+
+    def _materialize_operand(self, operand: ArrayOperand, workspace: np.ndarray):
+        if isinstance(operand, WorkspaceOperand):
+            raw = workspace[
+                operand.spec.location : operand.spec.location + operand.spec.count
+            ]
+            return np.reshape(raw, operand.shape, order="C")
+        value = operand.value
+        if isinstance(value, dok_ndarray):
+            return np.reshape(value.toarray(), operand.shape, order="C")
+        return value
+
+    def _eval_opaque_value(self, program: OpaqueProgram, workspace: np.ndarray):
         backend = get_backend_by_name("numpy", set_current=False)
-        evaluated = []
-        xi = iter(x)
-        for w in self.weights:
-            if isinstance(w, _AnyBW):
-                evaluated.append(w(next(xi)))
-            else:
-                evaluated.append(w)
-        return backend.call(self.op, *evaluated)
+        values = [
+            self._materialize_operand(operand, workspace) for operand in program.operands
+        ]
+        return backend.call(program.op, *values)
 
-    def push_forward(self, *tangent_space):
-        n_bw = sum(1 for w in self.weights if isinstance(w, _AnyBW))
-        x_bw_vals, dx_bw_vals = tangent_space[0:n_bw], tangent_space[n_bw:]
-        y = self(*x_bw_vals)
+    def _materialize_tangent(self, operand: ArrayOperand, dworkspace: np.ndarray):
+        if isinstance(operand, WorkspaceOperand):
+            raw = dworkspace[
+                operand.spec.location : operand.spec.location + operand.spec.count
+            ]
+            return np.reshape(raw, operand.shape, order="C")
+        value = operand.value
+        if isinstance(value, dok_ndarray):
+            return np.zeros(operand.shape, dtype=float)
+        if isinstance(value, (float, int, bool, np.bool_)):
+            return 0.0
+        if isinstance(value, Function):
+            return None
+        return 0.0
 
-        bw_iter = iter(zip(x_bw_vals, dx_bw_vals))
-        x_eval = []
-        dx_eval = []
-        for weight in self.weights:
-            if isinstance(weight, _AnyBW):
-                x_i, dx_i = next(bw_iter)
-                x_out, dx_out = weight.push_forwards(x_i, dx_i)
-                x_eval.append(x_out)
-                dx_eval.append(dx_out)
-            else:
-                constant = (
-                    weight
-                    if isinstance(weight, np.ndarray)
-                    else np.array([weight])
-                )
-                x_eval.append(constant)
-                dx_eval.append(np.zeros_like(constant))
+    def _eval_opaque_program(
+        self, program: OpaqueProgram, workspace: np.ndarray, dworkspace: np.ndarray
+    ):
+        backend = get_backend_by_name("numpy", set_current=False)
+        values = [self._materialize_operand(operand, workspace) for operand in program.operands]
 
-        df = differentials[self.op](*x_eval)
-        if all(isinstance(df_i, (dok_ndarray, np.ndarray)) for df_i in df):
-            dy = sum(df_i @ dx_i for df_i, dx_i in zip(df, dx_eval))
-        else:
-            dy = sum(df_i * dx_i for df_i, dx_i in zip(df, dx_eval))
-        return y, dy
+        if program.op == OP.EVALUATE and isinstance(values[0], Function):
+            from coker.backends.coker.core import create_opgraph
 
+            graph = create_opgraph(values[0])
+            tangents = [
+                self._materialize_tangent(operand, dworkspace)
+                for operand in program.operands[1:]
+            ]
+            result, dresult = graph.push_forward(*values[1:], *tangents)
+            return result, dresult
 
-def d_dot(x, y) -> Tuple:
-    # d = x.T @ y  = sum(x_iy_i)
-    # dd_i = y.T @ dx_i
-    # dd_i = x.T @ dy_i
-    return y.T, x.T
+        result = backend.call(program.op, *values)
+        tangents = [
+            self._materialize_tangent(operand, dworkspace) for operand in program.operands
+        ]
 
+        linear_like = program.op in {OP.TRANSPOSE}
+        if linear_like:
+            tangent = backend.call(program.op, *tangents)
+            return result, tangent
 
-differentials = {
-    OP.SIN: np.cos,
-    OP.COS: lambda x: -np.sin(x),
-    OP.MUL: lambda a, b: [b, a],
-    OP.ADD: lambda a, b: [1, 1],
-    OP.SUB: lambda a, b: [1, -1],
-    OP.DOT: d_dot,
-}
+        raise NotImplementedError(f"push_forward not implemented for opaque op {program.op}")

--- a/src/coker/backends/coker/op_impl.py
+++ b/src/coker/backends/coker/op_impl.py
@@ -4,6 +4,12 @@ from coker.backends.coker.sparse_tensor import dok_ndarray, is_constant
 from coker.backends.coker.tensor_contants import hat
 from coker.backends.coker.weights import BilinearWeights
 
+_CROSS_EPSILON = np.zeros((3, 3, 3))
+_CROSS_EPSILON[0, 1, 2] = _CROSS_EPSILON[1, 2, 0] = _CROSS_EPSILON[2, 0, 1] = 1
+_CROSS_EPSILON[2, 1, 0] = _CROSS_EPSILON[0, 2, 1] = _CROSS_EPSILON[1, 0, 2] = (
+    -1
+)
+
 
 def cross(x, y):
     if is_constant(x):
@@ -22,10 +28,6 @@ def cross(x, y):
         x.is_linear and y.is_linear
     ), "cross product of quadratic weights not supported"
 
-    eps = np.zeros((3, 3, 3))
-    eps[0, 1, 2] = eps[1, 2, 0] = eps[2, 0, 1] = 1
-    eps[2, 1, 0] = eps[0, 2, 1] = eps[1, 0, 2] = -1
-
     c_x = x.constant.toarray()  # shape (3,)
     c_y = y.constant.toarray()  # shape (3,)
     L_x = x.linear.toarray()  # shape (3, n)
@@ -38,9 +40,9 @@ def cross(x, y):
         -hat(c_y).toarray() @ L_x + hat(c_x).toarray() @ L_y
     )  # shape (3, n)
     # quadratic contribution: cross(L_x @ m, L_y @ m)
-    Q_result = np.einsum("ijk,js,kt->ist", eps, L_x, L_y)  # shape (3, n, n)
+    Q_result = np.einsum("ijk,js,kt->ist", _CROSS_EPSILON, L_x, L_y)
 
-    return BilinearWeights(
+    return BilinearWeights.from_trusted_dok(
         x.memory,
         (3,),
         constant=dok_ndarray.fromarray(c_result),

--- a/src/coker/backends/coker/sparse_tensor.py
+++ b/src/coker/backends/coker/sparse_tensor.py
@@ -128,17 +128,31 @@ class dok_ndarray(np.lib.mixins.NDArrayOperatorsMixin):
 
     @staticmethod
     def fromarray(other: np.ndarray):
+        other = np.asarray(other)
         shape = other.shape
 
-        keys = {}
-        with np.nditer(
-            other, op_flags=["readonly"], flags=["multi_index", "reduce_ok"]
-        ) as it:
-            for item in it:
-                if item != 0:
-                    index = tuple(it.multi_index)
-                    keys[index] = float(item)
+        if other.ndim == 0:
+            value = float(other)
+            if value == 0:
+                return dok_ndarray(shape)
+            return dok_ndarray(shape, {(): value})
 
+        nz = np.nonzero(other)
+        if len(nz) == 0 or nz[0].size == 0:
+            return dok_ndarray(shape)
+
+        values = other[nz]
+        if other.ndim == 1:
+            keys = {
+                (int(i),): float(v)
+                for i, v in zip(nz[0], values, strict=False)
+            }
+            return dok_ndarray(shape, keys)
+
+        keys = {
+            tuple(int(axis[row]) for axis in nz): float(values[row])
+            for row in range(values.size)
+        }
         return dok_ndarray(shape, keys)
 
     @staticmethod

--- a/src/coker/backends/coker/weights.py
+++ b/src/coker/backends/coker/weights.py
@@ -352,22 +352,53 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
         shape = (*self.shape[:-1], *other.shape[1:])
         return BilinearWeights(self.memory, shape, constant, linear, quadratic)
 
-    def compile(self) -> "_CompiledBW":
-        """Pre-materialise dok_ndarray tensors into dense numpy arrays."""
-        n = self.memory.count
-        flat = int(np.prod(self.shape))
-        c = self.constant.toarray().reshape(flat)
-        L = (
-            self.linear.toarray().reshape(flat, n)
-            if self.linear.keys
-            else None
+    def reshape(self, newshape: Tuple[int, ...], order="C") -> "BilinearWeights":
+        if order != "C":
+            raise NotImplementedError("Only C-order reshape is supported")
+        assert int(np.prod(self.shape)) == int(np.prod(newshape))
+
+        def _reshape_tensor(tensor: dok_ndarray) -> dok_ndarray:
+            if tensor.is_empty():
+                return dok_ndarray((*newshape, *tensor.shape[len(self.shape) :]))
+            data = {}
+            for key, value in tensor.keys.items():
+                out_key = key[: len(self.shape)]
+                mem_key = key[len(self.shape) :]
+                flat_index = np.ravel_multi_index(out_key, self.shape, order="C")
+                new_out_key = np.unravel_index(flat_index, newshape, order="C")
+                data[(*new_out_key, *mem_key)] = value
+            return dok_ndarray((*newshape, *tensor.shape[len(self.shape) :]), data)
+
+        return BilinearWeights(
+            self.memory,
+            newshape,
+            constant=_reshape_tensor(self.constant),
+            linear=_reshape_tensor(self.linear),
+            quadratic=_reshape_tensor(self.quadratic),
         )
-        Q = (
-            self.quadratic.toarray().reshape(flat, n, n)
-            if self.quadratic.keys
-            else None
+
+    def extend_memory(self, memory: MemorySpec) -> "BilinearWeights":
+        assert memory.location == 0
+        assert self.memory.location == 0
+        assert memory.count >= self.memory.count
+        if memory.count == self.memory.count:
+            return self.clone()
+
+        linear = dok_ndarray(
+            (*self.shape, memory.count),
+            {k: v for k, v in self.linear.keys.items()},
         )
-        return _CompiledBW(self.memory, self.shape, c, L, Q)
+        quadratic = dok_ndarray(
+            (*self.shape, memory.count, memory.count),
+            {k: v for k, v in self.quadratic.keys.items()},
+        )
+        return BilinearWeights(
+            memory,
+            self.shape,
+            constant=self.constant.clone(),
+            linear=linear,
+            quadratic=quadratic,
+        )
 
     def clone(self):
         return BilinearWeights(
@@ -437,8 +468,6 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
             dot(y_0, y_1) = dot(c_0, c_1)
                              + ((c_0.T @ L_1 + c_1.T @ L_0 x)
                              + (c_0.T @ Q_1 + c_1.T @ Q_0 + L_0.T @ L_1) (x,x)
-
-
         """
         assert self.memory == rhs.memory
         assert (
@@ -451,8 +480,8 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
         )
         memory_count = self.memory.count
         output_size = int(np.prod(self.shape))
-        c_self = self.constant.toarray().flatten()  # (output_size,)
-        c_rhs = rhs.constant.toarray().flatten()  # (output_size,)
+        c_self = self.constant.toarray().flatten()
+        c_rhs = rhs.constant.toarray().flatten()
         l_self = self.linear.toarray().reshape(output_size, memory_count)
         l_rhs = rhs.linear.toarray().reshape(output_size, memory_count)
         q_self = self.quadratic.toarray().reshape(
@@ -485,64 +514,25 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
 
     @staticmethod
     def identity2(memory: MemorySpec):
-
         shape = (memory.count,)
-        data = {}
-        for i in range(memory.count):
-            data[(i, i)] = 1
-
+        data = {(i, i): 1 for i in range(memory.count)}
         linear = dok_ndarray((memory.count, memory.count), data)
+        return BilinearWeights(memory, shape, linear=linear)
 
+    @staticmethod
+    def project(memory: MemorySpec, spec: MemorySpec, shape: tuple):
+        data = {}
+        for k in range(spec.count):
+            multi_idx = np.unravel_index(k, shape, order="C")
+            data[(*multi_idx, spec.location + k)] = 1
+        linear = dok_ndarray((*shape, memory.count), data)
         return BilinearWeights(memory, shape, linear=linear)
 
     @staticmethod
     def reshape_identity(memory: MemorySpec, shape: tuple):
-        """BilinearWeights that maps a flat vector of size memory.count
-        to the given shape."""
-        n = memory.count
-        data = {}
-        for k in range(n):
-            multi_idx = np.unravel_index(k, shape, order="C")
-            data[(*multi_idx, k)] = 1
-        linear = dok_ndarray((*shape, n), data)
-        return BilinearWeights(memory, shape, linear=linear)
-
-
-class _CompiledBW:
-    """Dense pre-materialised BilinearWeights for fast runtime evaluation.
-
-    Created by BilinearWeights.compile(). Stores constant/linear/quadratic
-    as plain numpy arrays so __call__ is a pure BLAS operation with no
-    Python dict iteration.
-    """
-
-    def __init__(self, memory, shape, c, L, Q):
-        self.memory = memory
-        self.shape = shape
-        self._c = c  # numpy (flat_out,)
-        self._L = L  # numpy (flat_out, n_mem) or None
-        self._Q = Q  # numpy (flat_out, n_mem, n_mem) or None
-
-    def __call__(self, x):
-        result = self._c.copy()
-        if self._L is not None:
-            result = result + self._L @ x
-        if self._Q is not None:
-            result = result + np.einsum("ijk,j,k->i", self._Q, x, x)
-        return result.reshape(self.shape)
-
-    def push_forwards(self, x, dx):
-        result = self._c.copy()
-        jac = np.zeros((result.size, len(x)))
-        if self._L is not None:
-            result = result + self._L @ x
-            jac = jac + self._L
-        if self._Q is not None:
-            result = result + np.einsum("ijk,j,k->i", self._Q, x, x)
-            jac = jac + np.einsum(
-                "ijk,k->ij", self._Q + self._Q.transpose(0, 2, 1), x
-            )
-        return result.reshape(self.shape), (jac @ dx).reshape(self.shape)
+        return BilinearWeights.project(
+            memory, MemorySpec(memory.location, memory.count), shape
+        )
 
 
 def outer_product(lhs: dok_ndarray, rhs: dok_ndarray):

--- a/src/coker/backends/coker/weights.py
+++ b/src/coker/backends/coker/weights.py
@@ -56,6 +56,36 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
             quadratic, expected_shape=(*shape, memory.count, memory.count)
         )
 
+    @classmethod
+    def from_trusted_dok(
+        cls,
+        memory: MemorySpec,
+        shape: Tuple[int, ...],
+        constant: dok_ndarray | None = None,
+        linear: dok_ndarray | None = None,
+        quadratic: dok_ndarray | None = None,
+    ) -> "BilinearWeights":
+        def _coerce(value, expected_shape: Tuple[int, ...]) -> dok_ndarray:
+            if value is None:
+                return dok_ndarray(expected_shape)
+            if isinstance(value, dok_ndarray):
+                return value
+            if isinstance(value, np.ndarray):
+                return dok_ndarray.fromarray(value)
+            raise TypeError(
+                f"Expected dok_ndarray or ndarray, got {type(value)}"
+            )
+
+        obj = cls.__new__(cls)
+        obj.memory = memory
+        obj.shape = shape
+        obj.constant = _coerce(constant, shape)
+        obj.linear = _coerce(linear, (*shape, memory.count))
+        obj.quadratic = _coerce(
+            quadratic, (*shape, memory.count, memory.count)
+        )
+        return obj
+
     def transpose(self) -> "BilinearWeights":
         if len(self.shape) == 1:
             (n,) = self.shape
@@ -300,7 +330,7 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
                 raise ex
             quadratic = other @ self.quadratic
             shape = constant.shape
-            return BilinearWeights(
+            return BilinearWeights.from_trusted_dok(
                 self.memory, shape, constant, linear, quadratic
             )
 
@@ -350,26 +380,36 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
             + linear_linear_quadratic
         )
         shape = (*self.shape[:-1], *other.shape[1:])
-        return BilinearWeights(self.memory, shape, constant, linear, quadratic)
+        return BilinearWeights.from_trusted_dok(
+            self.memory, shape, constant, linear, quadratic
+        )
 
-    def reshape(self, newshape: Tuple[int, ...], order="C") -> "BilinearWeights":
+    def reshape(
+        self, newshape: Tuple[int, ...], order="C"
+    ) -> "BilinearWeights":
         if order != "C":
             raise NotImplementedError("Only C-order reshape is supported")
         assert int(np.prod(self.shape)) == int(np.prod(newshape))
 
         def _reshape_tensor(tensor: dok_ndarray) -> dok_ndarray:
             if tensor.is_empty():
-                return dok_ndarray((*newshape, *tensor.shape[len(self.shape) :]))
+                return dok_ndarray(
+                    (*newshape, *tensor.shape[len(self.shape) :])
+                )
             data = {}
             for key, value in tensor.keys.items():
                 out_key = key[: len(self.shape)]
                 mem_key = key[len(self.shape) :]
-                flat_index = np.ravel_multi_index(out_key, self.shape, order="C")
+                flat_index = np.ravel_multi_index(
+                    out_key, self.shape, order="C"
+                )
                 new_out_key = np.unravel_index(flat_index, newshape, order="C")
                 data[(*new_out_key, *mem_key)] = value
-            return dok_ndarray((*newshape, *tensor.shape[len(self.shape) :]), data)
+            return dok_ndarray(
+                (*newshape, *tensor.shape[len(self.shape) :]), data
+            )
 
-        return BilinearWeights(
+        return BilinearWeights.from_trusted_dok(
             self.memory,
             newshape,
             constant=_reshape_tensor(self.constant),
@@ -392,7 +432,7 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
             (*self.shape, memory.count, memory.count),
             {k: v for k, v in self.quadratic.keys.items()},
         )
-        return BilinearWeights(
+        return BilinearWeights.from_trusted_dok(
             memory,
             self.shape,
             constant=self.constant.clone(),
@@ -401,7 +441,7 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
         )
 
     def clone(self):
-        return BilinearWeights(
+        return BilinearWeights.from_trusted_dok(
             self.memory,
             self.shape,
             self.constant.clone(),
@@ -429,7 +469,7 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
                 linear = -self.linear
                 quadratic = -self.quadratic
 
-                return BilinearWeights(
+                return BilinearWeights.from_trusted_dok(
                     self.memory, self.shape, constant, linear, quadratic
                 )
 
@@ -437,7 +477,7 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
 
     def __truediv__(self, other):
         if isinstance(other, scalar):
-            return BilinearWeights(
+            return BilinearWeights.from_trusted_dok(
                 self.memory,
                 self.shape,
                 self.constant / other,
@@ -510,14 +550,16 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
             linear_linear + c_self_quadratic + c_rhs_quadratic
         )
 
-        return BilinearWeights(self.memory, (1,), c, linear_weights, q)
+        return BilinearWeights.from_trusted_dok(
+            self.memory, (1,), c, linear_weights, q
+        )
 
     @staticmethod
     def identity2(memory: MemorySpec):
         shape = (memory.count,)
         data = {(i, i): 1 for i in range(memory.count)}
         linear = dok_ndarray((memory.count, memory.count), data)
-        return BilinearWeights(memory, shape, linear=linear)
+        return BilinearWeights.from_trusted_dok(memory, shape, linear=linear)
 
     @staticmethod
     def project(memory: MemorySpec, spec: MemorySpec, shape: tuple):
@@ -526,7 +568,7 @@ class BilinearWeights(np.lib.mixins.NDArrayOperatorsMixin):
             multi_idx = np.unravel_index(k, shape, order="C")
             data[(*multi_idx, spec.location + k)] = 1
         linear = dok_ndarray((*shape, memory.count), data)
-        return BilinearWeights(memory, shape, linear=linear)
+        return BilinearWeights.from_trusted_dok(memory, shape, linear=linear)
 
     @staticmethod
     def reshape_identity(memory: MemorySpec, shape: tuple):

--- a/src/coker/backends/numpy/core.py
+++ b/src/coker/backends/numpy/core.py
@@ -49,18 +49,22 @@ scalar_types = (
 def div(num, den):
     if isinstance(den, Tracer):
         return num / den
+    with np.errstate(divide="ignore", invalid="ignore"):
+        result = np.divide(num, den)
     try:
-        if den == 0:
-            if isinstance(num, np.ndarray) and (num == 0).all():
-                return num
-            elif num == 0:
-                return num
-            else:
-                raise ZeroDivisionError(num, den)
+        if np.isscalar(den) and den == 0:
+            if np.isscalar(num):
+                return float("nan")
+            return np.full_like(result, np.nan, dtype=float)
+        zero_mask = den == 0
     except ValueError:
-        pass
-
-    return np.divide(num, den)
+        return result
+    if np.isscalar(zero_mask):
+        return result
+    if np.any(zero_mask):
+        result = np.asarray(result, dtype=float)
+        result[zero_mask] = np.nan
+    return result
 
 
 impls = {


### PR DESCRIPTION
## Summary
- refactor the coker backend to execute full-workspace vector layers while preserving the backend API
- document the coker backend architecture and align divide-by-zero handling so `x / 0` yields `NaN`
- optimize hot sparse/lowering paths to remove the major compile-time bottlenecks in the coker backend

## Testing
- python -m black src
- pytest
- pytest tests/toolkits/kinematics/test_kinematics_examples.py --durations=10
- python -m cProfile -o .prof_hexapod_coker_opt.prof -m pytest "tests/toolkits/kinematics/test_kinematics_examples.py::test_hexapod_leg[coker]"
