### PR TITLE
Treat pre-solve parameters as fixed in CasADi solver

### DIFF
--- a/src/coker/backends/casadi/variational_solver.py
+++ b/src/coker/backends/casadi/variational_solver.py
@@ -55,13 +55,14 @@ class CasadiVariationalSolver(VariationalSolver):
 
         if self._initialiser is not None:
             initialised = self._initialiser(
-                x0=x0,
-                lbx=solver_arguments["lbx"],
-                ubx=solver_arguments["ubx"],
+                x0=solver_arguments["init_x0"],
+                p=solver_arguments["p_guess"],
+                lbx=solver_arguments["init_lbx"],
+                ubx=solver_arguments["init_ubx"],
                 lbg=solver_arguments["init_lbg"],
                 ubg=solver_arguments["init_ubg"],
             )
-            x0 = initialised["x"]
+            x0 = ca.vertcat(initialised["x"], solver_arguments["p_guess"])
             initial_cost = float(initialised["f"])
             assert (
                 initial_cost <= ca.inf
@@ -341,12 +342,18 @@ def create_variational_solver(
         ca.repmat(state_guess, n_reps), u_guess, p_guess_base
     )
 
+    init_decision_variables = ca.vertcat(path_symbols, u_symbols)
+    init_lower_bound_base = ca.vertcat(path_lower_bound, *u_lower)
+    init_upper_bound_base = ca.vertcat(path_upper_bound, *u_upper)
+    init_lbg = ca.vertcat(lbg, ca.DM.zeros(u_symbols.shape))
+    init_ubg = ca.vertcat(ubg, ca.DM.zeros(u_symbols.shape))
     init_solver = None
     if problem.transcription_options.initialise_near_guess:
         init_spec = {
             "f": cost,
-            "x": decision_variables,
-            "g": ca.vertcat(g, p_symbols, u_symbols),
+            "x": init_decision_variables,
+            "g": ca.vertcat(g, u_symbols),
+            "p": p_symbols,
         }
         init_solver = ca.nlpsol(
             "initialiser",
@@ -360,7 +367,9 @@ def create_variational_solver(
 
     parameter_offset = int(path_symbols.shape[0] + u_symbols.shape[0])
 
-    def map_arguments(fixed_parameters: Dict[str, arameterVariable]) -> Dict[str, ca.DM]:
+    def map_arguments(
+        fixed_parameters: Dict[str, ParameterVariable],
+    ) -> Dict[str, ca.DM]:
         unknown = sorted(set(fixed_parameters) - set(parameter_indices))
         if unknown:
             raise KeyError(f"Unknown solver parameters: {', '.join(unknown)}")
@@ -369,34 +378,37 @@ def create_variational_solver(
         lbx = ca.DM(lower_bound_base)
         ubx = ca.DM(upper_bound_base)
 
-        # Used if we're pre-solving.
+        path_x0 = ca.DM(decision_variables_0[:parameter_offset])
+        path_lbx = ca.DM(init_lower_bound_base)
+        path_ubx = ca.DM(init_upper_bound_base)
+
         p_guess = ca.DM(p_guess_base)
 
         for name, value in fixed_parameters.items():
+            index = parameter_indices[name]
             if isinstance(value, BoundedVariable):
-                index = parameter_indices[name]
                 p_guess[index] = value.guess
                 lbx[parameter_offset + index] = value.lower_bound
                 ubx[parameter_offset + index] = value.upper_bound
                 x0[parameter_offset + index] = value.guess
             else:
-                index = parameter_indices[name]
                 scalar = float(value)
                 p_guess[index] = scalar
                 lbx[parameter_offset + index] = scalar
                 ubx[parameter_offset + index] = scalar
                 x0[parameter_offset + index] = scalar
-
-        init_lbg = ca.vertcat(lbg, p_guess, ca.DM.zeros(u_symbols.shape))
-        init_ubg = ca.vertcat(ubg, p_guess, ca.DM.zeros(u_symbols.shape))
         return {
             "x0": x0,
             "lbx": lbx,
             "ubx": ubx,
             "lbg": lbg,
             "ubg": ubg,
+            "init_x0": path_x0,
+            "init_lbx": path_lbx,
+            "init_ubx": path_ubx,
             "init_lbg": init_lbg,
             "init_ubg": init_ubg,
+            "p_guess": p_guess,
         }
 
     solver = CasadiVariationalSolver(

--- a/tests/dynamical_systems/test_variational_solver.py
+++ b/tests/dynamical_systems/test_variational_solver.py
@@ -578,7 +578,12 @@ def test_reentrant_solver(variational_backend):
     assert abs(soln_0.parameter_solutions["value"] - param[0]) < 1e-4
     assert abs(soln_0.parameter_solutions["p1"] - param[1]) < 1e-4
 
-    soln_constrained = solver.solve(p1=param[1], value=BoundedVariable("value", upper_bound=3, lower_bound=0.5, guess=2))
+    soln_constrained = solver.solve(
+        p1=param[1],
+        value=BoundedVariable(
+            "value", upper_bound=3, lower_bound=0.5, guess=2
+        ),
+    )
     assert isinstance(soln_constrained, VariationalSolution)
     assert abs(soln_constrained.parameter_solutions["p1"] - param[1]) < 1e-9
 


### PR DESCRIPTION
## Summary
- pass user parameters to the CasADi initialiser through `p` instead of including them in the pre-solve decision vector
- keep the pre-solve problem restricted to path and control variables, then rebuild the full main-solver initial guess with the fixed parameter values
- fix the parameter type annotation typo in `map_arguments`

## Testing
- python -m pytest tests/dynamical_systems/test_variational_solver.py tests/dynamical_systems/test_variational_solver_callback.py
- python -m pytest tests/dynamical_systems
