### PR TITLE
Improve CasADi variational solver IPOPT handling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "coker"
-version = "0.3.24"
+version = "0.3.25"
 requires-python = ">=3.10"
 authors = [
     {name = "Peter Cudmore", email = "drpetercudmore@gmail.com"}

--- a/src/coker/backends/casadi/variational_solver.py
+++ b/src/coker/backends/casadi/variational_solver.py
@@ -25,6 +25,7 @@ from coker.optimisation import SolveFailure, solve_info_from_casadi_stats
 def noop(*_args):
     return None
 
+
 def _is_acceptable_small_search_direction(
     solve_info,
     result: Dict[str, ca.DM],
@@ -32,7 +33,7 @@ def _is_acceptable_small_search_direction(
     upper_bounds: ca.DM,
     *,
     tolerance: float,
-    min_tolerance: float = 1e-5
+    min_tolerance: float = 1e-5,
 ) -> bool:
     if solve_info.return_status != "Search_Direction_Becomes_Too_Small":
         return False
@@ -59,6 +60,7 @@ class CasadiVariationalSolver(VariationalSolver):
             [ca.DM, float, object], VariationalSolution
         ],
         initialiser: Optional[ca.Function] = None,
+        warm_start: bool = False,
     ):
         self.problem = problem
         self._parameters = parameters
@@ -66,6 +68,10 @@ class CasadiVariationalSolver(VariationalSolver):
         self._solver = solver
         self._assemble_solution = assemble_solution
         self._initialiser = initialiser
+        self._warm_start = warm_start
+        self._last_primal: Optional[ca.DM] = None
+        self._last_lam_x: Optional[ca.DM] = None
+        self._last_lam_g: Optional[ca.DM] = None
 
     @property
     def parameters(self) -> List[str]:
@@ -74,8 +80,23 @@ class CasadiVariationalSolver(VariationalSolver):
     def solve(self, **fixed_parameters) -> VariationalSolution:
         solver_arguments = self._map_arguments(fixed_parameters)
         x0 = solver_arguments["x0"]
+        solver_kwargs = {
+            "lbx": solver_arguments["lbx"],
+            "ubx": solver_arguments["ubx"],
+            "lbg": solver_arguments["lbg"],
+            "ubg": solver_arguments["ubg"],
+        }
 
-        if self._initialiser is not None:
+        if self._warm_start and self._last_primal is not None:
+            x0 = ca.fmin(
+                ca.fmax(self._last_primal, solver_kwargs["lbx"]),
+                solver_kwargs["ubx"],
+            )
+            if self._last_lam_x is not None:
+                solver_kwargs["lam_x0"] = self._last_lam_x
+            if self._last_lam_g is not None:
+                solver_kwargs["lam_g0"] = self._last_lam_g
+        elif self._initialiser is not None:
             initialised = self._initialiser(
                 x0=x0,
                 lbx=solver_arguments["lbx"],
@@ -91,10 +112,7 @@ class CasadiVariationalSolver(VariationalSolver):
 
         result = self._solver(
             x0=x0,
-            lbx=solver_arguments["lbx"],
-            ubx=solver_arguments["ubx"],
-            lbg=solver_arguments["lbg"],
-            ubg=solver_arguments["ubg"],
+            **solver_kwargs,
         )
         solve_info = solve_info_from_casadi_stats(self._solver.stats())
         if not solve_info.success:
@@ -103,7 +121,9 @@ class CasadiVariationalSolver(VariationalSolver):
                 result,
                 solver_arguments["lbg"],
                 solver_arguments["ubg"],
-                tolerance=self.problem.transcription_options.absolute_tolerance,
+                tolerance=(
+                    self.problem.transcription_options.absolute_tolerance
+                ),
             ):
                 solve_info = replace(solve_info, success=True)
             else:
@@ -112,6 +132,10 @@ class CasadiVariationalSolver(VariationalSolver):
                     f"{solve_info.return_status}",
                     solve_info,
                 )
+        if self._warm_start:
+            self._last_primal = result["x"]
+            self._last_lam_x = result["lam_x"]
+            self._last_lam_g = result["lam_g"]
         return self._assemble_solution(
             result["x"],
             float(result["f"]),
@@ -325,6 +349,7 @@ def create_variational_solver(
         ubg = ca.vertcat(ubg, g_upper)
 
     solver_options = dict(problem.transcription_options.optimiser_options)
+    warm_start = bool(solver_options.pop("warm_start", False))
     if not problem.transcription_options.verbose:
         solver_options.update(
             {
@@ -352,6 +377,8 @@ def create_variational_solver(
 
     callback_wrapper = None
     nlp_solver_options = dict(solver_options)
+    if warm_start:
+        nlp_solver_options["ipopt.warm_start_init_point"] = "yes"
     if problem.transcription_options.interation_callback is not None:
         callback_wrapper = CallbackWrapper.new(
             "variational_iteration_callback",
@@ -444,6 +471,7 @@ def create_variational_solver(
         solver=nlp_solver,
         assemble_solution=assemble_solution,
         initialiser=init_solver,
+        warm_start=warm_start,
     )
     solver._callback_wrapper = callback_wrapper
     return solver

--- a/src/coker/backends/casadi/variational_solver.py
+++ b/src/coker/backends/casadi/variational_solver.py
@@ -1,3 +1,4 @@
+from dataclasses import replace
 from itertools import accumulate
 from typing import Callable, Dict, List, Optional, Tuple
 
@@ -23,6 +24,27 @@ from coker.optimisation import SolveFailure, solve_info_from_casadi_stats
 
 def noop(*_args):
     return None
+
+def _is_acceptable_small_search_direction(
+    solve_info,
+    result: Dict[str, ca.DM],
+    lower_bounds: ca.DM,
+    upper_bounds: ca.DM,
+    *,
+    tolerance: float,
+    min_tolerance: float = 1e-5
+) -> bool:
+    if solve_info.return_status != "Search_Direction_Becomes_Too_Small":
+        return False
+    objective = float(result["f"])
+    if not np.isfinite(objective):
+        return False
+    residual = result["g"]
+    if residual.numel() == 0:
+        return True
+    violation = ca.fmax(lower_bounds - residual, residual - upper_bounds)
+    max_violation = float(ca.mmax(ca.fmax(violation, 0)))
+    return max_violation <= max(tolerance, min_tolerance)
 
 
 class CasadiVariationalSolver(VariationalSolver):
@@ -76,11 +98,20 @@ class CasadiVariationalSolver(VariationalSolver):
         )
         solve_info = solve_info_from_casadi_stats(self._solver.stats())
         if not solve_info.success:
-            raise SolveFailure(
-                "CasADi variational solve failed with status "
-                f"{solve_info.return_status}",
+            if _is_acceptable_small_search_direction(
                 solve_info,
-            )
+                result,
+                solver_arguments["lbg"],
+                solver_arguments["ubg"],
+                tolerance=self.problem.transcription_options.absolute_tolerance,
+            ):
+                solve_info = replace(solve_info, success=True)
+            else:
+                raise SolveFailure(
+                    "CasADi variational solve failed with status "
+                    f"{solve_info.return_status}",
+                    solve_info,
+                )
         return self._assemble_solution(
             result["x"],
             float(result["f"]),

--- a/tests/dynamical_systems/test_variational_solver.py
+++ b/tests/dynamical_systems/test_variational_solver.py
@@ -589,3 +589,97 @@ def test_reentrant_solver(variational_backend):
 
     with pytest.raises(KeyError):
         solver.solve(unknown_parameter=0.0)
+
+
+def test_reentrant_solver_warm_starts_from_previous_solution(
+    variational_backend,
+):
+    def x0(p):
+        return p[0:2]
+
+    def xdot(x, p):
+        A = np.array([[p[2], 0], [0, p[3]]])
+        return A @ x
+
+    param = np.array([1, 1, 4, 3])
+
+    def solution(t, p):
+        exp_at = np.array([[np.exp(p[2] * t), 0], [0, np.exp(p[3] * t)]])
+        return exp_at @ x0(p)
+
+    system = create_autonomous_ode(
+        parameters=VectorSpace("p", 4), x0=x0, xdot=xdot, backend="numpy"
+    )
+
+    def loss(f, p_inner):
+        total_error = 0.0
+        for t_i in [0.4, 0.6, 1]:
+            truth = solution(t_i, param)
+            test = f(t_i, p_inner)
+            error = truth - test
+            total_error += error.T @ error
+        return total_error
+
+    problem = VariationalProblem(
+        loss=loss,
+        system=system,
+        parameters=[
+            BoundedVariable("value", upper_bound=3, lower_bound=0.5, guess=2),
+            BoundedVariable("p1", upper_bound=3, lower_bound=0.5, guess=2),
+            float(param[2]),
+            float(param[3]),
+        ],
+        t_final=1,
+        backend=variational_backend,
+    )
+    problem.transcription_options.optimiser_options = {"warm_start": True}
+
+    solver = problem.get_solver()
+    assert solver is not None
+
+    class TrackingInitialiser:
+        def __init__(self, delegate):
+            self._delegate = delegate
+            self.calls = 0
+
+        def __call__(self, *args, **kwargs):
+            self.calls += 1
+            return self._delegate(*args, **kwargs)
+
+    class TrackingSolver:
+        def __init__(self, delegate):
+            self._delegate = delegate
+            self.calls = []
+            self.results = []
+
+        def __call__(self, *args, **kwargs):
+            self.calls.append(kwargs)
+            result = self._delegate(*args, **kwargs)
+            self.results.append(result)
+            return result
+
+        def stats(self):
+            return self._delegate.stats()
+
+    solver._initialiser = TrackingInitialiser(solver._initialiser)
+    solver._solver = TrackingSolver(solver._solver)
+
+    first = solver.solve()
+    second = solver.solve()
+
+    assert isinstance(first, VariationalSolution)
+    assert isinstance(second, VariationalSolution)
+    assert solver._initialiser.calls == 1
+    assert len(solver._solver.calls) == 2
+    assert np.allclose(
+        np.asarray(solver._solver.calls[1]["x0"]),
+        np.asarray(solver._solver.results[0]["x"]),
+    )
+    assert np.allclose(
+        np.asarray(solver._solver.calls[1]["lam_x0"]),
+        np.asarray(solver._solver.results[0]["lam_x"]),
+    )
+    assert np.allclose(
+        np.asarray(solver._solver.calls[1]["lam_g0"]),
+        np.asarray(solver._solver.results[0]["lam_g"]),
+    )


### PR DESCRIPTION
## Summary
- accept IPOPT small-search-direction exits when the variational solve is already feasible
- add optional CasADi variational solver warm starts via `transcription_options.optimiser_options['warm_start']`
- cache and reuse both primal and dual solver outputs between successive solves

## Testing
- python -m pytest tests/dynamical_systems/test_variational_solver.py -k "reentrant_solver"
- python -m pytest tests/dynamical_systems/test_variational_solver.py
- uv run black --check --diff src
- uv run flake8 src tests docs examples scripts