### PR TITLE
Fix LGR root ordering on newer NumPy

### DIFF
--- a/src/coker/dynamics/transcription_helpers.py
+++ b/src/coker/dynamics/transcription_helpers.py
@@ -66,6 +66,7 @@ def lgr_points(n: int) -> List[float]:
             -(legendre_coefficient(n - 1, i) + legendre_coefficient(n, i))
             / leading_term
         )
+    # tol=1000 means imaginary parts below ~1000 * machine eps are treated as round-off noise.
     roots = np.real_if_close(np.linalg.eigvals(companion_matrix), tol=1000)
     roots = np.sort(np.asarray(roots, dtype=float)).tolist()
     roots.append(1.0)

--- a/src/coker/dynamics/transcription_helpers.py
+++ b/src/coker/dynamics/transcription_helpers.py
@@ -66,7 +66,7 @@ def lgr_points(n: int) -> List[float]:
             -(legendre_coefficient(n - 1, i) + legendre_coefficient(n, i))
             / leading_term
         )
-    # tol=1000 means imaginary parts below ~1000 * machine eps are treated as round-off noise.
+    # tol=1000 treats sub-1000-eps imaginary parts as round-off noise.
     roots = np.real_if_close(np.linalg.eigvals(companion_matrix), tol=1000)
     roots = np.sort(np.asarray(roots, dtype=float)).tolist()
     roots.append(1.0)

--- a/src/coker/dynamics/transcription_helpers.py
+++ b/src/coker/dynamics/transcription_helpers.py
@@ -66,9 +66,9 @@ def lgr_points(n: int) -> List[float]:
             -(legendre_coefficient(n - 1, i) + legendre_coefficient(n, i))
             / leading_term
         )
-    roots = np.linalg.eigvals(companion_matrix).tolist()
-    roots.append(1)
-    roots.sort()
+    roots = np.real_if_close(np.linalg.eigvals(companion_matrix), tol=1000)
+    roots = np.sort(np.asarray(roots, dtype=float)).tolist()
+    roots.append(1.0)
 
     return [-1] + roots[1:]
 


### PR DESCRIPTION
## Summary
- coerce nearly-real LGR eigenvalues back to real scalars before sorting
- sort LGR roots with NumPy instead of Python's ordering on complex values
- restore compatibility with newer NumPy releases used in CI

## Testing
- pytest tests/dynamical_systems/test_helpers.py tests/backends/casadi/test_transcription.py tests/dynamical_systems/test_variational_solver.py tests/dynamical_systems/test_variational_solver_callback.py -q
